### PR TITLE
Fix: Remove problematic comment from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN chmod +x /app/meraki_pihole_sync.py # Make python script executable
 
 # Copy the entrypoint and cron wrapper scripts and make them executable
 COPY ./scripts/docker-entrypoint.sh /docker-entrypoint.sh
-COPY ./scripts/run_sync_for_cron.sh /app/run_sync_for_cron.sh # Copy wrapper to /app
+COPY ./scripts/run_sync_for_cron.sh /app/run_sync_for_cron.sh
 RUN chmod +x /docker-entrypoint.sh
 RUN chmod +x /app/run_sync_for_cron.sh
 


### PR DESCRIPTION
Attempting to resolve a Docker build error that may have been caused by a comment on a COPY line. The error message was:

failed to solve: failed to compute cache key: failed to calculate checksum of ref ... "/wrapper": not found

This change removes the comment from the line copying `run_sync_for_cron.sh`.