### PR TITLE
Fix: Correct Meraki SDK usage and cron Python invocation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN chmod +x /app/meraki_pihole_sync.py # Make python script executable
 
 # Copy the entrypoint and cron wrapper scripts and make them executable
 COPY ./scripts/docker-entrypoint.sh /docker-entrypoint.sh
-COPY ./scripts/run_sync_for_cron.sh /app/run_sync_for_cron.sh # Copy wrapper to /app
+COPY ./scripts/run_sync_for_cron.sh /app/run_sync_for_cron.sh
 RUN chmod +x /docker-entrypoint.sh
 RUN chmod +x /app/run_sync_for_cron.sh
 

--- a/app/meraki_pihole_sync.py
+++ b/app/meraki_pihole_sync.py
@@ -234,7 +234,7 @@ def get_all_relevant_meraki_clients(dashboard: meraki.DashboardAPI, config: dict
                 # This might be an over-optimization; let's try fetching directly and handle errors.
                 # network_info = dashboard.networks.getNetwork(network_id)
                 # if 'appliance' in network_info.get('productTypes', []):
-                appliance_dhcp_subnets = dashboard.appliance.getNetworkApplianceDhcpSubnets(network_id)
+                appliance_dhcp_subnets = dashboard.appliance.get_network_appliance_dhcp_subnets(networkId=network_id)
                 # else:
                 #    logging.info(f"Network {network_name} (ID: {network_id}) is not an Appliance network or does not have DHCP subnets configured via API. Skipping DHCP reservation check for it.")
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -70,9 +70,9 @@ else
   # Explicitly set PATH for the cron job environment. These are common paths.
   echo "PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin" > "${CRON_FILE_PATH}"
   # Removing 'root' user from the cron line. For /etc/cron.d files, this typically means the command runs as root.
-  # The command will now be the wrapper script.
+  # The command will now be the wrapper script, explicitly run with /bin/bash.
   CRON_WRAPPER_SCRIPT_PATH="/app/run_sync_for_cron.sh" # Path where the wrapper will be in the container
-  echo "${CRON_SCHEDULE} ${CRON_WRAPPER_SCRIPT_PATH}" >> "${CRON_FILE_PATH}" # Wrapper script handles its own logging to CRON_OUTPUT_LOG_FILE
+  echo "${CRON_SCHEDULE} /bin/bash ${CRON_WRAPPER_SCRIPT_PATH}" >> "${CRON_FILE_PATH}" # Wrapper script handles its own logging to CRON_OUTPUT_LOG_FILE
   echo "" >> "${CRON_FILE_PATH}" # Ensure cron file ends with a newline
   chmod 0644 "${CRON_FILE_PATH}"
 


### PR DESCRIPTION
- Updated `app/meraki_pihole_sync.py` to use the correct snake_case method `get_network_appliance_dhcp_subnets` with the `networkId` keyword arg for the Meraki SDK.
- Modified `scripts/docker-entrypoint.sh` to explicitly use `/bin/bash` for executing the cron wrapper script, aiming to resolve `python: not found` errors in the cron environment.