### PR TITLE
⚡ Bolt: prevent N+1 query issue in Pi-hole DNS sync

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2025-02-13 - O(N*M) nested loop found in `_map_devices` endpoint
 **Learning:** Found an O(N*M) nested loop in `_map_devices` (`app/app.py`) that maps Meraki clients to Pi-hole records. This caused slow API responses for endpoints like `/mappings` and `/stream`.
 **Action:** Replaced the inner loop with an O(1) dictionary lookup by pre-computing `ip_to_domains`. This brought a synthetic test of 5000 clients and 2000 records from ~0.624s down to ~0.016s.
+## 2025-01-26 - Prevent N+1 queries in loop
+**Learning:** Found an N+1 query problem in loop fetching Pi-hole custom DNS records when processing each Meraki client.
+**Action:** When working with API or DB clients, verify if functions fetching records inside loops can accept a pre-fetched records dict as an optional arg.

--- a/app/clients/pihole_client.py
+++ b/app/clients/pihole_client.py
@@ -121,7 +121,7 @@ class PiholeClient:
             return None
         return records
 
-    def add_or_update_dns_record(self, domain, new_ip):
+    def add_or_update_dns_record(self, domain, new_ip, existing_records=None):
         domain_cleaned = domain.strip().lower()
         new_ip_cleaned = new_ip.strip()
 
@@ -129,7 +129,9 @@ class PiholeClient:
             log.warning("Skipping invalid record", domain=domain, ip=new_ip)
             return False
 
-        existing_records = self.get_custom_dns_records()
+        # Bolt: Avoid N+1 requests by accepting existing_records as an argument
+        if existing_records is None:
+            existing_records = self.get_custom_dns_records()
         if existing_records is None:
             log.error("Cannot add or update DNS record: existing Pi-hole records cache is None.")
             return False

--- a/app/sync_logic.py
+++ b/app/sync_logic.py
@@ -235,7 +235,8 @@ def sync_pihole_dns(update_type=None):
                     domain_to_sync = f"{client_name_sanitized}{config['hostname_suffix']}"
                     ip_to_sync = client["ip"]
 
-                    if pihole_client.add_or_update_dns_record(domain_to_sync, ip_to_sync):
+                    # Bolt: Pass existing_pihole_records to avoid an API call (N+1 query problem) on every client
+                    if pihole_client.add_or_update_dns_record(domain_to_sync, ip_to_sync, existing_records=existing_pihole_records):
                         timestamp = datetime.now()
                         mapping_line = f"{timestamp}: Mapped {domain_to_sync} to {ip_to_sync}\n"
                         if mapping_line not in previous_mappings:

--- a/tests/test_meraki_pihole_sync.py
+++ b/tests/test_meraki_pihole_sync.py
@@ -35,7 +35,7 @@ class TestMerakiPiholeSync(unittest.TestCase):
         # Assert
         self.assertEqual(mock_get_meraki_data.call_count, 1)
         mock_pihole_client.return_value.add_or_update_dns_record.assert_called_once_with(
-            "test-client-1.lan", "192.168.1.10"
+            "test-client-1.lan", "192.168.1.10", existing_records={}
         )
 
     @patch('app.sync_logic.load_app_config_from_env')


### PR DESCRIPTION
💡 What: Added an optional `existing_records` argument to `PiholeClient.add_or_update_dns_record` and passed the already-fetched `existing_pihole_records` from `sync_pihole_dns`.
🎯 Why: Avoids fetching the entire list of custom DNS records repeatedly from the Pi-hole API for every single Meraki client inside the main loop.
📊 Impact: Reduces Pi-hole API queries by a factor of O(N) (where N is the number of Meraki clients).
🔬 Measurement: Verify by checking network logs / API calls during a sync cycle, or run `poetry run pytest tests/test_meraki_pihole_sync.py tests/test_pihole_client.py`.

---
*PR created automatically by Jules for task [13625632949547109486](https://jules.google.com/task/13625632949547109486) started by @brewmarsh*