### PR TITLE
🎨 Palette: Add ARIA roles and labels to Chart.js canvases

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-06-26 - Accessibility improvements for form inputs and interactive elements
 **Learning:** Bootstrap form-text helpers should be explicitly linked to their inputs using `aria-describedby`. Decorative icons like `▼` should be hidden from screen readers using `aria-hidden="true"`. Tooltip and label improvements (`aria-label` and `title`) are simple to add but greatly improve UX for log actions like Copy and Clear.
 **Action:** Next time, ensure all form help text and purely decorative icons are appropriately tagged with ARIA attributes to enhance accessibility and usability.
+
+## 2024-03-24 - Accessibility for Chart.js canvas elements
+**Learning:** Screen readers cannot interpret the visual data drawn on `<canvas>` elements by default, often reading them as empty or ignoring them. For data visualizations like Chart.js, adding `role="img"` and a descriptive `aria-label` provides crucial context to assistive technologies.
+**Action:** Always add `role="img"` and descriptive `aria-label`s explaining what the chart represents when implementing canvas-based visualizations.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -59,15 +59,15 @@
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-md-6">
-                                    <canvas id="device-chart"></canvas>
+                                    <canvas id="device-chart" role="img" aria-label="Device status chart showing mapped and unmapped devices"></canvas>
                                 </div>
                                 <div class="col-md-6">
-                                    <canvas id="record-chart"></canvas>
+                                    <canvas id="record-chart" role="img" aria-label="Bar chart showing Pi-hole and Meraki record counts"></canvas>
                                 </div>
                             </div>
                             <div class="row mt-4">
                                 <div class="col-md-12">
-                                    <canvas id="history-chart"></canvas>
+                                    <canvas id="history-chart" role="img" aria-label="Line chart showing mapped devices history over time"></canvas>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
💡 **What**: The UX enhancement added `role="img"` and descriptive `aria-label`s to the three `<canvas>` elements (`device-chart`, `record-chart`, and `history-chart`) rendered by Chart.js.
🎯 **Why**: Canvas elements are opaque to screen readers by default. By explicitly defining their role and adding context-rich labels, assistive technologies can now communicate the purpose of these visualizations rather than ignoring them or reading them as empty elements.
♿ **Accessibility**: Adds meaningful context for the dashboard charts for screen reader users, enabling better overall inclusion and comprehension of the data presentation.

---
*PR created automatically by Jules for task [3895656098668964706](https://jules.google.com/task/3895656098668964706) started by @brewmarsh*