### PR TITLE
🎨 Palette: Fix accordion ARIA and caret synchronization

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-03-24 - Accessibility for Chart.js canvas elements
 **Learning:** Screen readers cannot interpret the visual data drawn on `<canvas>` elements by default, often reading them as empty or ignoring them. For data visualizations like Chart.js, adding `role="img"` and a descriptive `aria-label` provides crucial context to assistive technologies.
 **Action:** Always add `role="img"` and descriptive `aria-label`s explaining what the chart represents when implementing canvas-based visualizations.
+## 2023-10-27 - Accordion ARIA & Caret Synchronization
+**Learning:** Manual `click` event listeners to toggle `aria-expanded` and caret states (`▲`/`▼`) on Bootstrap accordions can easily fall out of sync or be implemented backwards. In this case, the ARIA state was reversed, and the initial caret state in the HTML contradicted the actual expanded DOM state.
+**Action:** Always prefer hooking into the UI framework's native lifecycle events (e.g., Bootstrap's `show.bs.collapse` and `hide.bs.collapse`) for visual and ARIA toggles rather than brittle manual DOM event listeners. Ensure initial HTML markup matches the default state of components.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -53,7 +53,7 @@
                 <div class="card mt-4" id="charts-card">
                     <div class="card-header" data-bs-toggle="collapse" data-bs-target="#charts-body">
                         Charts
-                        <span class="caret float-end" aria-hidden="true">▼</span>
+                        <span class="caret float-end" aria-hidden="true">▲</span>
                     </div>
                     <div id="charts-body" class="collapse show">
                         <div class="card-body">
@@ -399,16 +399,21 @@
                 }
             }
 
-            header.addEventListener('click', () => {
-                const caret = header.querySelector('.caret');
-                if (caret.textContent === '▼') {
-                    caret.textContent = '▲';
-                    header.setAttribute('aria-expanded', 'false');
-                } else {
-                    caret.textContent = '▼';
-                    header.setAttribute('aria-expanded', 'true');
+            if (targetId) {
+                const targetEl = document.getElementById(targetId);
+                if (targetEl) {
+                    targetEl.addEventListener('show.bs.collapse', () => {
+                        header.setAttribute('aria-expanded', 'true');
+                        const caret = header.querySelector('.caret');
+                        if (caret) caret.textContent = '▲';
+                    });
+                    targetEl.addEventListener('hide.bs.collapse', () => {
+                        header.setAttribute('aria-expanded', 'false');
+                        const caret = header.querySelector('.caret');
+                        if (caret) caret.textContent = '▼';
+                    });
                 }
-            });
+            }
 
             header.addEventListener('keydown', (e) => {
                 if (e.key === 'Enter' || e.key === ' ') {


### PR DESCRIPTION
💡 What: Replaced fragile manual DOM toggles for accordion state with Bootstrap 5 native collapse events and fixed the initial HTML state of the Charts panel.
🎯 Why: The previous logic announced the inverted state to screen readers (visually open but announced false) and the initial Charts panel caret contradicted its expanded state. 
♿ Accessibility: Ensures `aria-expanded` accurately reflects the DOM state for screen readers at all times, making the UI robustly accessible via both mouse and keyboard navigation.

---
*PR created automatically by Jules for task [18163676903182410378](https://jules.google.com/task/18163676903182410378) started by @brewmarsh*