### PR TITLE
⚡ Bolt: Add multithreading to Meraki client fetching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,6 @@
 ## 2025-06-27 - Repeated overhead per request in Middleware
 **Learning:** Middleware functions that execute on every request can introduce significant latency overhead if they repeatedly parse unchanging strings or configurations (e.g., parsing an environment variable into `ip_network` objects for every single HTTP request). Also learned that Starlette's `TestClient` defaults `request.client.host` to `"testclient"`, which throws a `ValueError` if passed to `ip_address()`.
 **Action:** When working on middleware, check if any variables are static across the app's lifecycle and pre-compute/cache them within the class instance. Use checks on the raw string before re-parsing, and gracefully handle `TestClient` exceptions when reading host IPs.
+## 2025-08-16 - Synchronous API fetching in loop replaced by Multithreading
+**Learning:** Found an N+1 query problem where the list of relevant Meraki devices is looped over to fetch fixed IP assignments sequentially. Since each fetch involves a slow HTTP API call to the Meraki Dashboard, processing many devices took a significantly long time.
+**Action:** Replaced the sequential looping over devices with a `concurrent.futures.ThreadPoolExecutor` to execute the HTTP requests concurrently. For large sets of devices, fetching in parallel drastically reduces synchronization wait time and overall latency.

--- a/app/clients/meraki_client.py
+++ b/app/clients/meraki_client.py
@@ -1,3 +1,5 @@
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
 import meraki
 import structlog
 
@@ -58,6 +60,11 @@ def get_all_relevant_meraki_clients(dashboard: meraki.DashboardAPI, config: dict
     3. For each device, fetches the fixed IP assignments.
     4. Return a list of these clients with the necessary information for DNS syncing.
 
+    ⚡ Bolt Optimization: Uses ThreadPoolExecutor to concurrently fetch fixed IP
+    assignments from multiple devices. This prevents the N+1 API call problem from
+    being completely synchronous, dramatically reducing the time to fetch all
+    clients for large organizations.
+
     Args:
         dashboard (meraki.DashboardAPI): Initialized Meraki Dashboard API client.
         config (dict): The application configuration dictionary.
@@ -75,10 +82,17 @@ def get_all_relevant_meraki_clients(dashboard: meraki.DashboardAPI, config: dict
         log.error("Meraki API error while fetching organization devices", error=e, org_id=org_id)
         return []
 
-    for device in devices:
+    def fetch_for_device(device):
         if device['model'].startswith('MS'):
-            relevant_clients.extend(_get_fixed_ip_assignments_from_switch(dashboard, device))
+            return _get_fixed_ip_assignments_from_switch(dashboard, device)
         elif device['model'].startswith('MX'):
-            relevant_clients.extend(_get_fixed_ip_assignments_from_appliance(dashboard, device))
+            return _get_fixed_ip_assignments_from_appliance(dashboard, device)
+        return []
+
+    # Use a ThreadPoolExecutor to fetch device data in parallel
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        futures = [executor.submit(fetch_for_device, device) for device in devices]
+        for future in as_completed(futures):
+            relevant_clients.extend(future.result())
 
     return relevant_clients


### PR DESCRIPTION
* 💡 What: Replaced sequential network fetches in `get_all_relevant_meraki_clients` with concurrent execution using `ThreadPoolExecutor`.
* 🎯 Why: Looping through many organization devices to fetch fixed IP assignments synchronously introduces a severe N+1 API bottleneck, causing long sync times. Multithreading prevents this.
* 📊 Impact: Considerably faster API fetching and data aggregation, reducing the overall time for a background sync, specifically for Meraki organizations containing a large number of MX/MS devices.
* 🔬 Measurement: The optimization impact can be measured by profiling the duration of `get_all_relevant_meraki_clients` when configured to a larger test organization containing tens/hundreds of devices and comparing to the sequential baseline.

---
*PR created automatically by Jules for task [13948792441736280571](https://jules.google.com/task/13948792441736280571) started by @brewmarsh*