### PR TITLE
🎨 Palette: Add explicit focus to welcome screen for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2023-10-27 - Accordion ARIA & Caret Synchronization
 **Learning:** Manual `click` event listeners to toggle `aria-expanded` and caret states (`▲`/`▼`) on Bootstrap accordions can easily fall out of sync or be implemented backwards. In this case, the ARIA state was reversed, and the initial caret state in the HTML contradicted the actual expanded DOM state.
 **Action:** Always prefer hooking into the UI framework's native lifecycle events (e.g., Bootstrap's `show.bs.collapse` and `hide.bs.collapse`) for visual and ARIA toggles rather than brittle manual DOM event listeners. Ensure initial HTML markup matches the default state of components.
+
+## 2026-06-30 - Accessible Focus on Custom Overlays
+**Learning:** When displaying custom overlay modals or screens (like `#welcome-screen`), keyboard users may not immediately understand context because focus remains on the underlying content behind the modal. The browser doesn't automatically move focus to dynamically shown elements unless they are native dialogs.
+**Action:** Always ensure that when displaying custom overlays, the active focus is explicitly set via `.focus()` to the primary action or close button within the overlay.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -454,6 +454,7 @@
 
             if (!localStorage.getItem('welcomeScreenSeen')) {
                 document.getElementById('welcome-screen').style.display = 'flex';
+                document.getElementById('close-welcome-screen').focus();
             }
 
             document.getElementById('close-welcome-screen').addEventListener('click', () => {


### PR DESCRIPTION
💡 What: Added `document.getElementById('close-welcome-screen').focus();` when the welcome screen overlay is displayed.
🎯 Why: Keyboard users and screen readers may not immediately understand context when a custom overlay is displayed because the browser leaves focus on the background content.
♿ Accessibility: Ensures that keyboard users are immediately focused on the primary action (the "Get Started" close button) when the application first loads and the modal appears.

---
*PR created automatically by Jules for task [2234734334874050489](https://jules.google.com/task/2234734334874050489) started by @brewmarsh*