### PR TITLE
🎨 Palette: Improve sync interval inline validation and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-06-30 - Accessible Focus on Custom Overlays
 **Learning:** When displaying custom overlay modals or screens (like `#welcome-screen`), keyboard users may not immediately understand context because focus remains on the underlying content behind the modal. The browser doesn't automatically move focus to dynamically shown elements unless they are native dialogs.
 **Action:** Always ensure that when displaying custom overlays, the active focus is explicitly set via `.focus()` to the primary action or close button within the overlay.
+
+## 2026-07-02 - Inline validation for non-form inputs
+**Learning:** Native HTML5 validation attributes (like `min` and `max`) do not automatically prevent action when an input is used outside of a `<form>` submission context. In standalone inputs, JavaScript must explicitly check `.reportValidity()` before executing logic or making API calls, otherwise the browser allows invalid states to silently pass.
+**Action:** Whenever using standalone inputs linked to buttons (e.g., input groups), always use `.reportValidity()` in the button click handler to trigger native browser validation tooltips and block invalid actions.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -163,8 +163,8 @@
                         <div class="mb-3">
                             <label for="sync-interval" class="form-label">Sync Interval (seconds)</label>
                             <div class="input-group">
-                                <input type="number" class="form-control" id="sync-interval" value="{{ sync_interval }}" aria-describedby="sync-interval-help">
-                                <button class="btn btn-outline-secondary" id="update-interval">Update</button>
+                                <input type="number" class="form-control" id="sync-interval" min="1" max="86400" value="{{ sync_interval }}" aria-describedby="sync-interval-help">
+                                <button class="btn btn-outline-secondary" id="update-interval" aria-label="Update sync interval">Update</button>
                             </div>
                             <div id="sync-interval-help" class="form-text">The interval between automatic syncs.</div>
                         </div>
@@ -252,12 +252,15 @@
         });
 
         document.getElementById('update-interval').addEventListener('click', (event) => {
+            const intervalInput = document.getElementById('sync-interval');
+            if (!intervalInput.reportValidity()) return;
+
             const btn = event.currentTarget;
             const originalHTML = btn.innerHTML;
             btn.disabled = true;
             btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Updating...';
 
-            const interval = document.getElementById('sync-interval').value;
+            const interval = intervalInput.value;
             fetch('/update-interval', {
                 method: 'POST',
                 headers: {


### PR DESCRIPTION
💡 What: Added client-side HTML5 inline validation (`min="1"`, `max="86400"`, and `.reportValidity()`) to the sync interval input field. Also added an `aria-label` to the update button.
🎯 Why: Natively prevents invalid inputs (like 0, negative values, or letters) from triggering a backend fetch and shows the browser's built-in validation error tooltip, preventing silent failures or UI hang states.
📸 Before/After: Before, an invalid interval would trigger a fetch request that would fail silently or return a 422 error while getting stuck on "Updating...". After, the browser blocks the action and shows a tooltip natively.
♿ Accessibility: Screen reader users now get clear context for the purely visual "Update" button via the `aria-label`, and the native validation API correctly notifies users when their input is out of bounds.

---
*PR created automatically by Jules for task [684986185449016051](https://jules.google.com/task/684986185449016051) started by @brewmarsh*