### PR TITLE
🎨 Palette: Add skip-to-content link and main landmark

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2026-07-02 - Inline validation for non-form inputs
 **Learning:** Native HTML5 validation attributes (like `min` and `max`) do not automatically prevent action when an input is used outside of a `<form>` submission context. In standalone inputs, JavaScript must explicitly check `.reportValidity()` before executing logic or making API calls, otherwise the browser allows invalid states to silently pass.
 **Action:** Whenever using standalone inputs linked to buttons (e.g., input groups), always use `.reportValidity()` in the button click handler to trigger native browser validation tooltips and block invalid actions.
+
+## 2026-07-03 - Skip-to-content links and semantic landmarks
+**Learning:** For users relying on screen readers or keyboard navigation, encountering a lot of navigation links before getting to the main content can be tedious. A "Skip to main content" link using a combination of a visually-hidden class that appears on focus and a `<main>` semantic landmark target provides a quick bypass.
+**Action:** Use `.visually-hidden-focusable` (or equivalent utility classes) for the skip link, and ensure the target area uses a semantic landmark like `<main id="main-content" tabindex="-1">` to programmatically define the main content area for screen readers.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,6 +11,7 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="visually-hidden-focusable position-absolute top-0 start-0 z-3 p-3 m-2 bg-primary text-white rounded text-decoration-none shadow">Skip to main content</a>
     {% if show_welcome_banner %}
     <div id="welcome-screen">
         <div class="card">
@@ -47,7 +48,7 @@
         </div>
     </nav>
 
-    <div class="container">
+    <main class="container" id="main-content" tabindex="-1">
         <div class="row mt-4">
             <div class="col-md-8">
                 <div class="card mt-4" id="charts-card">
@@ -172,7 +173,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    </main>
 
     <div class="toast-container position-fixed bottom-0 end-0 p-3">
       <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">


### PR DESCRIPTION
💡 What: Added a visually-hidden-focusable "Skip to main content" link at the top of the body, targeting a newly defined semantic `<main id="main-content" tabindex="-1">` landmark instead of the generic `<div class="container">`.

🎯 Why: Keyboard-only users and screen reader users frequently face a block of navigation links before the core content of a page. A bypass link improves navigation speed and usability.

📸 Before/After: Before, keyboard users had to tab through the navigation bar first. After, the first tab brings up the skip link, and hitting Enter immediately focuses the `<main>` container, allowing them to tab straight into the charts/cards area.

♿ Accessibility:
- Adds WCAG-compliant Skip Navigation link functionality using Bootstrap 5 classes.
- Enhances semantic layout structure by changing the primary content wrapper to `<main role="main">`.
- Makes the main container programmatically focusable without adding it to the default tab order (`tabindex="-1"`).

---
*PR created automatically by Jules for task [10935018357621469955](https://jules.google.com/task/10935018357621469955) started by @brewmarsh*