### PR TITLE
🎨 Palette: Improve interactive ARIA roles for card headers and switches

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2026-07-02 - Inline validation for non-form inputs
 **Learning:** Native HTML5 validation attributes (like `min` and `max`) do not automatically prevent action when an input is used outside of a `<form>` submission context. In standalone inputs, JavaScript must explicitly check `.reportValidity()` before executing logic or making API calls, otherwise the browser allows invalid states to silently pass.
 **Action:** Whenever using standalone inputs linked to buttons (e.g., input groups), always use `.reportValidity()` in the button click handler to trigger native browser validation tooltips and block invalid actions.
+
+## 2026-07-04 - Programmatic ARIA Attribute Scoping
+**Learning:** When using JavaScript to programmatically apply accessibility attributes (like `tabindex` and `role="button"`) to UI components using broad CSS classes (like `.card-header`), you risk applying them to static elements that should not be interactive. This creates confusing phantom buttons for screen readers and clutters the keyboard tab order.
+**Action:** Always use specific attribute selectors (e.g., `[data-bs-toggle="collapse"]`) when programmatically attaching ARIA roles or keyboard event listeners to ensure they are only applied to genuinely interactive variants of a component.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -41,7 +41,7 @@
                 Meraki Pi-hole Sync
             </a>
             <div class="form-check form-switch ms-auto">
-                <input class="form-check-input" type="checkbox" id="darkModeSwitch">
+                <input class="form-check-input" type="checkbox" role="switch" id="darkModeSwitch">
                 <label class="form-check-label" for="darkModeSwitch">Dark Mode</label>
             </div>
         </div>
@@ -388,7 +388,7 @@
             }
         });
 
-        document.querySelectorAll('.card-header').forEach(header => {
+        document.querySelectorAll('.card-header[data-bs-toggle="collapse"]').forEach(header => {
             header.setAttribute('tabindex', '0');
             header.setAttribute('role', 'button');
             const targetId = header.getAttribute('data-bs-target')?.substring(1);


### PR DESCRIPTION
💡 **What**: 
- Added `role="switch"` to the Dark Mode toggle input.
- Narrowed the JavaScript selector for dynamically applying `role="button"` and `tabindex="0"` from all `.card-header` elements to only those with `[data-bs-toggle="collapse"]`.

🎯 **Why**: 
Previously, the JavaScript logic blindly applied button semantics and keyboard focus to all card headers on the page. This included static headers like the "Controls" panel header, turning them into confusing "phantom buttons" for screen reader users and cluttering the keyboard tab flow unnecessarily. The Dark Mode toggle was also missing semantic context.

📸 **Before/After**: 
*Visual appearance remains unchanged, but keyboard navigation now correctly skips the static "Controls" header.*

♿ **Accessibility**: 
- Improved screen reader experience by ensuring only truly collapsible card headers are announced as buttons.
- Streamlined keyboard tab order by removing focusability from static headers.
- Enhanced semantic clarity of the Dark Mode toggle for assistive technologies.

---
*PR created automatically by Jules for task [15877473429472774301](https://jules.google.com/task/15877473429472774301) started by @brewmarsh*