### PR TITLE
⚡ Bolt: Prevent thread pool starvation in stream endpoint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -14,3 +14,7 @@
 ## 2025-08-16 - Synchronous API fetching in loop replaced by Multithreading
 **Learning:** Found an N+1 query problem where the list of relevant Meraki devices is looped over to fetch fixed IP assignments sequentially. Since each fetch involves a slow HTTP API call to the Meraki Dashboard, processing many devices took a significantly long time.
 **Action:** Replaced the sequential looping over devices with a `concurrent.futures.ThreadPoolExecutor` to execute the HTTP requests concurrently. For large sets of devices, fetching in parallel drastically reduces synchronization wait time and overall latency.
+
+## 2024-05-18 - Async Generators for StreamingResponse in FastAPI
+**Learning:** In FastAPI, returning a synchronous generator in a StreamingResponse blocks a worker thread from the underlying thread pool while it waits for the generator to yield. When implementing Server-Sent Events (SSE) that wait, this can easily lead to thread pool starvation where all workers are busy waiting, making the server unresponsive.
+**Action:** Always use an `async def` generator for `StreamingResponse`. Offload any blocking I/O (like reading files or network requests) inside the async generator to a separate thread using `await asyncio.to_thread()`, and use `await asyncio.sleep()` for any delays.

--- a/app/app.py
+++ b/app/app.py
@@ -1,7 +1,7 @@
+import asyncio
 import json
 import os
 import threading
-import time
 from contextlib import asynccontextmanager
 from ipaddress import ip_address, ip_network
 from pathlib import Path
@@ -154,28 +154,34 @@ async def check_pihole_error(request: Request):
 @app.get("/stream")
 @limiter.limit(get_rate_limit)
 async def stream(request: Request):
-    def event_stream():
+    def read_files_and_get_mappings():
+        log_file = Path('/app/logs/sync.log')
+        if not log_file.exists():
+            log_file.touch()
+        log_content = log_file.read_text()
+
+        changelog_file = Path('/app/changelog.log')
+        if not changelog_file.exists():
+            changelog_file.touch()
+        changelog_content = changelog_file.read_text()
+
+        mappings = get_mappings_data()
+        return log_content, changelog_content, mappings
+
+    async def event_stream():
         while True:
             try:
-                log_file = Path('/app/logs/sync.log')
-                if not log_file.exists():
-                    log_file.touch()
-                log_content = log_file.read_text()
+                log_content, changelog_content, mappings = await asyncio.to_thread(read_files_and_get_mappings)
+
                 yield f"data: {json.dumps({'log': log_content})}\n\n"
-
-                changelog_file = Path('/app/changelog.log')
-                if not changelog_file.exists():
-                    changelog_file.touch()
-                changelog_content = changelog_file.read_text()
                 yield f"data: {json.dumps({'changelog': changelog_content})}\n\n"
-
-                mappings = get_mappings_data()
                 yield f"data: {json.dumps({'mappings': mappings})}\n\n"
             except Exception as e:
                 log.error("Error in event stream", error=e)
                 yield f"data: {json.dumps({'error': 'An error occurred in the stream.'})}\n\n"
             finally:
-                time.sleep(get_sync_interval())
+                interval = await asyncio.to_thread(get_sync_interval)
+                await asyncio.sleep(interval)
 
     return StreamingResponse(event_stream(), media_type='text/event-stream')
 


### PR DESCRIPTION
💡 What: Changed the synchronous generator `event_stream` used in `app.py` for Server-Sent Events (SSE) into an asynchronous generator. I/O operations (like reading files and mapping) are now offloaded to `asyncio.to_thread()`, and sleep relies on `await asyncio.sleep()`. Also avoided redefining an inner function inside the `while True` loop.
🎯 Why: Returning a synchronous generator in a FastAPI `StreamingResponse` blocks a worker thread from the thread pool. Because the generator loops continuously with sleeps, it easily causes thread pool starvation and makes the app unresponsive to further requests.
📊 Impact: Ensures FastAPI's asynchronous thread pool correctly scales, avoiding the situation where the server becomes completely unresponsive while multiple clients are connected to the SSE stream.
🔬 Measurement: Verify server responsiveness during simultaneous connections to the `/stream` endpoint. Code runs properly and all unit tests passed.

---
*PR created automatically by Jules for task [16509814960357836785](https://jules.google.com/task/16509814960357836785) started by @brewmarsh*