### PR TITLE
🎨 Palette: Add required attribute to sync interval input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,7 @@
 ## 2026-07-04 - Programmatic ARIA Attribute Scoping
 **Learning:** When using JavaScript to programmatically apply accessibility attributes (like `tabindex` and `role="button"`) to UI components using broad CSS classes (like `.card-header`), you risk applying them to static elements that should not be interactive. This creates confusing phantom buttons for screen readers and clutters the keyboard tab order.
 **Action:** Always use specific attribute selectors (e.g., `[data-bs-toggle="collapse"]`) when programmatically attaching ARIA roles or keyboard event listeners to ensure they are only applied to genuinely interactive variants of a component.
+
+## 2026-07-05 - Native form validation for standalone required inputs
+**Learning:** When using standalone inputs (outside a `<form>` tag) that are required, simply adding the `required` attribute is highly effective when paired with `.reportValidity()` in the associated button's click handler. This blocks invalid empty submissions and leverages the browser's native, accessible validation tooltips without needing custom error UI.
+**Action:** Always add the `required` attribute to mandatory standalone inputs and ensure their linked action buttons check `.reportValidity()` before executing logic or making API calls.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -163,7 +163,7 @@
                         <div class="mb-3">
                             <label for="sync-interval" class="form-label">Sync Interval (seconds)</label>
                             <div class="input-group">
-                                <input type="number" class="form-control" id="sync-interval" min="1" max="86400" value="{{ sync_interval }}" aria-describedby="sync-interval-help">
+                                <input type="number" class="form-control" id="sync-interval" min="1" max="86400" value="{{ sync_interval }}" aria-describedby="sync-interval-help" required>
                                 <button class="btn btn-outline-secondary" id="update-interval" aria-label="Update sync interval">Update</button>
                             </div>
                             <div id="sync-interval-help" class="form-text">The interval between automatic syncs.</div>


### PR DESCRIPTION
💡 What: Added the `required` attribute to the sync interval number input in the frontend.
🎯 Why: Submitting an empty interval previously bypassed frontend validation and resulted in a silent 422 Unprocessable Entity error from the backend.
📸 Before/After: Before, an empty input would silently fail on click. After, the native browser tooltip blocks submission, indicating the field must be filled.
♿ Accessibility: The `required` attribute semantically informs screen readers that the input is mandatory, improving context for users relying on assistive technologies.

---
*PR created automatically by Jules for task [10914018709051556167](https://jules.google.com/task/10914018709051556167) started by @brewmarsh*