### PR TITLE
⚡ Bolt: [performance improvement] Prevent N+1 API calls in SSE stream with TTL cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2025-10-24 - O(N*M) nested loop found in `sync_pihole_dns`
 **Learning:** Found an O(N*M) nested loop in `sync_pihole_dns` (`app/sync_logic.py`) that checks if a mapping line exists in a list of previous mappings read from `changelog.log`. Checking membership in a list takes O(N) time and runs for every client mapped, leading to O(N*M) time complexity.
 **Action:** The old function checks `if mapping_line not in previous_mappings:` where `previous_mappings` is a list. By converting `previous_mappings` to a set (`previous_mappings_set = set(previous_mappings)`), we can look up the mapped lines in O(1) time and eliminate the O(N) inner loop. Also ensure to add the newly written line to the set (`previous_mappings_set.add(mapping_line)`) to prevent duplicate mapping writes on the same run.
+
+## 2025-10-25 - Prevent N+1 API calls in SSE streams
+**Learning:** Making live external API calls (e.g. `get_mappings_data`) inside a Server-Sent Events (SSE) `while True` loop can cause an N+1 query problem per connected client, leading to excessive API requests, rate limiting, and thread blocking.
+**Action:** Always read data from a background-updated local cache (e.g. `cache.json` updated by a separate daemon) rather than making direct, live API requests inside the stream loop to prevent N+1 issues in SSE streams.

--- a/app/app.py
+++ b/app/app.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import threading
+import time
 from contextlib import asynccontextmanager
 from ipaddress import ip_address, ip_network
 from pathlib import Path
@@ -242,7 +243,17 @@ def _map_devices(meraki_clients, pihole_records):
 
     return mapped_devices, unmapped_meraki_devices
 
+_mappings_cache = None
+_mappings_cache_time = 0
+
 def get_mappings_data():
+    global _mappings_cache, _mappings_cache_time
+    # ⚡ Bolt Optimization: Use an in-memory TTL cache to prevent N+1 API calls
+    # Impact: Significantly reduces load on Meraki/Pi-hole APIs during SSE streams.
+    # Measurement: Compare API request logs during an active SSE connection.
+    if _mappings_cache is not None and time.time() < _mappings_cache_time + 60:
+        return _mappings_cache
+
     try:
         config = load_app_config_from_env()
         pihole_url = os.getenv("PIHOLE_API_URL")
@@ -255,7 +266,10 @@ def get_mappings_data():
         meraki_clients = _get_meraki_data(config)
         mapped_devices, unmapped_meraki_devices = _map_devices(meraki_clients, pihole_records)
 
-        return {"pihole": pihole_records, "meraki": meraki_clients, "mapped": mapped_devices, "unmapped_meraki": unmapped_meraki_devices}
+        result = {"pihole": pihole_records, "meraki": meraki_clients, "mapped": mapped_devices, "unmapped_meraki": unmapped_meraki_devices}
+        _mappings_cache = result
+        _mappings_cache_time = time.time()
+        return result
     except Exception as e:
         log.error("Error in get_mappings_data", error=e)
         return {}


### PR DESCRIPTION
### 💡 What
Implemented a 60-second in-memory TTL cache using global variables (`_mappings_cache` and `_mappings_cache_time`) in `app/app.py` for the `get_mappings_data()` function. 

### 🎯 Why
Inside the `/stream` Server-Sent Events (SSE) endpoint, there is a `while True` loop that repeatedly calls `get_mappings_data()`. Previously, this resulted in an N+1 query problem per connected client, bombarding the external Meraki and Pi-hole APIs with requests on every tick, causing rate limit issues and blocking worker threads.

### 📊 Impact
Significantly reduces the load on Meraki and Pi-hole APIs during active SSE connections. If multiple clients are connected or the stream loops quickly, API requests are restricted to at most once per 60 seconds per process.

### 🔬 Measurement
Verified via code analysis. Monitoring external API calls with and without this change during an active SSE connection will show the requests flatlining at 1 per minute rather than spiking continuously. All tests passed.

---
*PR created automatically by Jules for task [7365508660241924827](https://jules.google.com/task/7365508660241924827) started by @brewmarsh*