### PR TITLE
🎨 Palette: Scope interaction cursors and add hover states to collapsible headers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2026-07-07 - Visual Feedback for Drag and Drop operations
 **Learning:** By default, libraries like Sortable.js handle the DOM reordering but provide little out-of-the-box visual feedback during the actual drag operation, which can leave users confused about where an element will drop.
 **Action:** Always provide CSS styling for the `sortable-ghost` (or equivalent) class provided by drag-and-drop libraries to visually indicate the drop zone (e.g., using lowered opacity and dashed borders), and update the cursor states (`grab` and `grabbing`) on the drag handles to improve interaction clarity. Ensure these styles are tested in both light and dark modes.
+
+## 2026-07-08 - Visual Feedback for Draggable and Collapsible Elements
+**Learning:** Applying broad CSS rules like `cursor: grab` to generic classes (e.g., `.card-header`) unintentionally styles static components (like a "Controls" panel header) as interactive. Furthermore, elements that are both draggable and clickable (collapsible accordions) often lack visual `:hover` affordances because native buttons handle this, but custom `div` headers do not.
+**Action:** Always scope interactive cursors and hover states to specific data attributes (e.g., `[data-bs-toggle="collapse"]`). Additionally, always add subtle `:hover` background color transitions (in both light and dark modes) to interactive custom components to ensure they feel actionable to mouse users.

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -10,12 +10,20 @@
 }
 
 .card-header {
-    cursor: move;
-    cursor: grab;
     position: relative;
 }
 
-.card-header:active {
+.card-header[data-bs-toggle="collapse"] {
+    cursor: move;
+    cursor: grab;
+    transition: background-color 0.2s ease-in-out;
+}
+
+.card-header[data-bs-toggle="collapse"]:hover {
+    background-color: #e9ecef;
+}
+
+.card-header[data-bs-toggle="collapse"]:active {
     cursor: grabbing;
 }
 
@@ -54,6 +62,10 @@
 
 .dark-mode .card-header {
     background-color: #555555;
+}
+
+.dark-mode .card-header[data-bs-toggle="collapse"]:hover {
+    background-color: #666666;
 }
 
 .dark-mode .card-title {


### PR DESCRIPTION
💡 What: Scoped `cursor: grab` and active states to only target `.card-header[data-bs-toggle="collapse"]`, removing it from the global `.card-header` class. Added a subtle `:hover` background color state for both light and dark modes to these interactive headers.
🎯 Why: The generic styling caused static headers (like the "Controls" panel) to display a "grab" cursor, implying they were interactive or draggable when they were not. Furthermore, the collapsible accordion headers lacked any visual `:hover` affordance to indicate they were clickable, which is a key interaction gap for custom div-based interactive elements compared to native buttons.
📸 Before/After: Verified via Playwright screenshot & video. Static headers no longer show drag cursors; collapsible headers now have a hover state and retain their grab cursor.
♿ Accessibility: Improves visual accessibility by ensuring hover states explicitly communicate interactivity for custom accordion triggers that lacked native button styles.

---
*PR created automatically by Jules for task [18013306638264625853](https://jules.google.com/task/18013306638264625853) started by @brewmarsh*