### PR TITLE
⚡ Bolt: Eliminate redundant API polling in SSE stream and optimize function scopes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,6 @@
 ## 2025-10-25 - Prevent N+1 API calls in SSE streams
 **Learning:** Making live external API calls (e.g. `get_mappings_data`) inside a Server-Sent Events (SSE) `while True` loop can cause an N+1 query problem per connected client, leading to excessive API requests, rate limiting, and thread blocking.
 **Action:** Always read data from a background-updated local cache (e.g. `cache.json` updated by a separate daemon) rather than making direct, live API requests inside the stream loop to prevent N+1 issues in SSE streams.
+## 2025-10-26 - Static inner helper functions definition overhead
+**Learning:** Found static inner helper functions `read_sync_log` and `read_changelog` defined inside `event_stream` generator inside `stream` endpoint (`app/app.py`). Defining inner functions that do not rely on local variable scoping inside an endpoint, or inside loops, causes unnecessary function re-definition overhead per request.
+**Action:** Move static inner helper functions outside the function scope if they don't depend on the outer function's local variables, moving them to module level or at least outside loops/generators.

--- a/app/app.py
+++ b/app/app.py
@@ -156,41 +156,30 @@ async def update_pihole(request: Request):
         log.error("Error starting Pi-hole update", error=e)
         return JSONResponse(content={"message": "Pi-hole update failed to start."}, status_code=500)
 
-@app.get("/check-pihole-error")
-@limiter.limit(get_rate_limit)
-async def check_pihole_error(request: Request):
+
+
+def read_sync_log():
     log_file = Path('/app/logs/sync.log')
-    if log_file.exists():
-        from collections import deque
-        with log_file.open("r") as f:
-            # 🛡️ Sentinel: Prevent Memory Exhaustion DoS by limiting read
-            log_content = "".join(deque(f, maxlen=1000))
-        if "Pi-hole API returned a 'forbidden' error" in log_content:
-            return JSONResponse(content={"error": "forbidden"})
-    return JSONResponse(content={})
+    if not log_file.exists():
+        log_file.touch()
+    from collections import deque
+    with log_file.open("r") as f:
+        # 🛡️ Sentinel: Prevent Memory Exhaustion DoS by limiting read
+        return "".join(deque(f, maxlen=1000))
+
+def read_changelog():
+    changelog_file = Path('/app/changelog.log')
+    if not changelog_file.exists():
+        changelog_file.touch()
+    from collections import deque
+    with changelog_file.open("r") as f:
+        # 🛡️ Sentinel: Prevent Memory Exhaustion DoS by limiting read
+        return "".join(deque(f, maxlen=1000))
 
 @app.get("/stream")
 @limiter.limit(get_rate_limit)
 async def stream(request: Request):
     async def event_stream():
-        def read_sync_log():
-            log_file = Path('/app/logs/sync.log')
-            if not log_file.exists():
-                log_file.touch()
-            from collections import deque
-            with log_file.open("r") as f:
-                # 🛡️ Sentinel: Prevent Memory Exhaustion DoS by limiting read
-                return "".join(deque(f, maxlen=1000))
-
-        def read_changelog():
-            changelog_file = Path('/app/changelog.log')
-            if not changelog_file.exists():
-                changelog_file.touch()
-            from collections import deque
-            with changelog_file.open("r") as f:
-                # 🛡️ Sentinel: Prevent Memory Exhaustion DoS by limiting read
-                return "".join(deque(f, maxlen=1000))
-
         while True:
             try:
                 log_content = await asyncio.to_thread(read_sync_log)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -327,13 +327,9 @@
                 const data = JSON.parse(event.data);
                 if (data.log) {
                     document.getElementById('sync-log').textContent = data.log;
-                    fetch('/check-pihole-error')
-                        .then(response => response.json())
-                        .then(errorData => {
-                            if (errorData.error === 'forbidden') {
-                                showToast("Pi-hole API returned a 'forbidden' error. Please ensure 'webserver.api.app_sudo' is set to true in your Pi-hole configuration.");
-                            }
-                        });
+                    if (data.log.includes("Pi-hole API returned a 'forbidden' error")) {
+                        showToast("Pi-hole API returned a 'forbidden' error. Please ensure 'webserver.api.app_sudo' is set to true in your Pi-hole configuration.");
+                    }
                 }
                 if (data.changelog) {
                     document.getElementById('changelog').textContent = data.changelog;


### PR DESCRIPTION
💡 **What:** 
1. Eliminated a redundant `fetch('/check-pihole-error')` API polling from the frontend `index.html` when receiving Server-Sent Events (SSE). Instead, the frontend directly checks if the error message is present in the `data.log` string that was already transmitted in the SSE payload.
2. Moved static inner helper functions `read_sync_log` and `read_changelog` from the `stream` endpoint's body (`app/app.py`) to the module level.
3. Cleaned up the now-unused backend `/check-pihole-error` endpoint.

🎯 **Why:** 
1. The frontend fired a separate `fetch` request every time an SSE event was received, just to read the same log file that was already being transmitted. This caused unnecessary network chatter and high-frequency redundant HTTP requests.
2. Defining functions inside an endpoint that do not rely on local variables causes unnecessary function re-definition overhead for every request, wasting CPU cycles.

📊 **Impact:** 
- Significantly reduces server load and unnecessary network chatter by removing a high-frequency redundant HTTP request.
- Prevents Python from constantly redefining function objects, reducing request overhead.

🔬 **Measurement:**
- Compare Network tab traffic before and after the change; observe that a `/check-pihole-error` API request is no longer fired every time a stream event occurs.

---
*PR created automatically by Jules for task [15344030301518459383](https://jules.google.com/task/15344030301518459383) started by @brewmarsh*