### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IP Whitelist authorization bypass (testclient backdoor)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** IP whitelist bypass behind reverse proxies due to relying solely on `request.client.host`.
 **Learning:** Depending on the client's host directly in environments using reverse proxies allows attackers to spoof the client IP and bypass IP whitelisting restrictions.
 **Prevention:** Use standard forwarding headers (`X-Forwarded-For` or `X-Real-IP`) to extract the client IP, or handle client IP logic robustly according to reverse proxy configuration.
+## 2026-07-10 - Fix IPWhitelistMiddleware Test Backdoor
+**Vulnerability:** A hardcoded `client_ip_str == "testclient"` check was left in production middleware, allowing any attacker to bypass IP whitelisting by passing headers like `X-Forwarded-For: testclient` which would then be authorized as `127.0.0.1`.
+**Learning:** Testing shortcuts left in production code create critical security vulnerabilities, particularly when combined with proxy header trusting where the client string can be fully spoofed.
+**Prevention:** Never leave backdoor strings for testing in production security logic. In FastAPI testing, use the `client` argument in `TestClient(app, client=('127.0.0.1', 12345))` to properly mock the request client IP instead.

--- a/app/app.py
+++ b/app/app.py
@@ -101,8 +101,6 @@ class IPWhitelistMiddleware(BaseHTTPMiddleware):
                 elif request.headers.get("X-Real-IP"):
                     client_ip_str = request.headers.get("X-Real-IP").strip()
 
-            if client_ip_str == "testclient":
-                client_ip_str = "127.0.0.1"
             try:
                 client_ip = ip_address(client_ip_str)
             except ValueError:


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: A hardcoded `if client_ip_str == "testclient":` check was left in `IPWhitelistMiddleware` which acts as an authorization bypass backdoor.
🎯 **Impact**: Attackers could spoof headers like `X-Forwarded-For: testclient` to be treated as `127.0.0.1` and bypass IP whitelisting restrictions, gaining unauthorized access to the application endpoints.
🔧 **Fix**: Removed the `testclient` backdoor logic from the middleware. Tests already utilize `TestClient(app, client=("127.0.0.1", 12345))` correctly to mock the IP.
✅ **Verification**: Run `poetry run pytest`. All tests should pass and `X-Forwarded-For: testclient` will no longer bypass IP restrictions.

---
*PR created automatically by Jules for task [3314862283639337539](https://jules.google.com/task/3314862283639337539) started by @brewmarsh*