### PR TITLE
⚡ Bolt: Prevent redundant API polling in SSE stream

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,6 @@
 ## 2025-10-25 - Prevent N+1 API calls in SSE streams
 **Learning:** Making live external API calls (e.g. `get_mappings_data`) inside a Server-Sent Events (SSE) `while True` loop can cause an N+1 query problem per connected client, leading to excessive API requests, rate limiting, and thread blocking.
 **Action:** Always read data from a background-updated local cache (e.g. `cache.json` updated by a separate daemon) rather than making direct, live API requests inside the stream loop to prevent N+1 issues in SSE streams.
+## 2025-10-25 - Redundant API Polling in SSE Streams
+**Learning:** Found a redundant HTTP GET request to `/check-pihole-error` being made every time an SSE message was received on the frontend. This created unnecessary network traffic and backend server load, effectively negating the benefits of using an SSE stream for pushing updates.
+**Action:** When a frontend uses an SSE stream to receive data, check if any supplemental API calls made upon message receipt can be eliminated by including the necessary state directly in the SSE payload or by parsing the existing payload locally.

--- a/app/app.py
+++ b/app/app.py
@@ -156,19 +156,6 @@ async def update_pihole(request: Request):
         log.error("Error starting Pi-hole update", error=e)
         return JSONResponse(content={"message": "Pi-hole update failed to start."}, status_code=500)
 
-@app.get("/check-pihole-error")
-@limiter.limit(get_rate_limit)
-async def check_pihole_error(request: Request):
-    log_file = Path('/app/logs/sync.log')
-    if log_file.exists():
-        from collections import deque
-        with log_file.open("r") as f:
-            # 🛡️ Sentinel: Prevent Memory Exhaustion DoS by limiting read
-            log_content = "".join(deque(f, maxlen=1000))
-        if "Pi-hole API returned a 'forbidden' error" in log_content:
-            return JSONResponse(content={"error": "forbidden"})
-    return JSONResponse(content={})
-
 @app.get("/stream")
 @limiter.limit(get_rate_limit)
 async def stream(request: Request):

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -327,13 +327,11 @@
                 const data = JSON.parse(event.data);
                 if (data.log) {
                     document.getElementById('sync-log').textContent = data.log;
-                    fetch('/check-pihole-error')
-                        .then(response => response.json())
-                        .then(errorData => {
-                            if (errorData.error === 'forbidden') {
-                                showToast("Pi-hole API returned a 'forbidden' error. Please ensure 'webserver.api.app_sudo' is set to true in your Pi-hole configuration.");
-                            }
-                        });
+                    // ⚡ Bolt Optimization: Removed redundant /check-pihole-error fetch.
+                    // The log content is already in data.log, so we just check it directly.
+                    if (data.log.includes("Pi-hole API returned a 'forbidden' error")) {
+                        showToast("Pi-hole API returned a 'forbidden' error. Please ensure 'webserver.api.app_sudo' is set to true in your Pi-hole configuration.");
+                    }
                 }
                 if (data.changelog) {
                     document.getElementById('changelog').textContent = data.changelog;


### PR DESCRIPTION
**💡 What:** 
Eliminated a redundant HTTP GET request to `/check-pihole-error` in the frontend that occurred every time an SSE message was received. The backend `/check-pihole-error` endpoint has been removed.

**🎯 Why:** 
The application was making an unnecessary API request on every SSE event just to check for a specific string ("Pi-hole API returned a 'forbidden' error") in the logs. Since the SSE stream already pushes the log content (`data.log`), this check can be done locally in the frontend, saving network round trips and reducing the backend API surface.

**📊 Impact:** 
- Reduces network requests significantly for connected clients.
- Removes an unused endpoint and reduces file I/O operations on the backend.
- Simplifies backend code by eliminating `check_pihole_error`.

**🔬 Measurement:** 
- Review the network tab in the browser developer tools while an active SSE connection is pushing logs. Observe that no `/check-pihole-error` requests are made when SSE messages arrive.
- Ensured all tests pass and no functionality is broken by verifying that `poetry run pytest` succeeds.

---
*PR created automatically by Jules for task [1510293573829017832](https://jules.google.com/task/1510293573829017832) started by @brewmarsh*