### PR TITLE
🎨 Palette: Scope interactive styles to collapsible card headers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2026-07-07 - Visual Feedback for Drag and Drop operations
 **Learning:** By default, libraries like Sortable.js handle the DOM reordering but provide little out-of-the-box visual feedback during the actual drag operation, which can leave users confused about where an element will drop.
 **Action:** Always provide CSS styling for the `sortable-ghost` (or equivalent) class provided by drag-and-drop libraries to visually indicate the drop zone (e.g., using lowered opacity and dashed borders), and update the cursor states (`grab` and `grabbing`) on the drag handles to improve interaction clarity. Ensure these styles are tested in both light and dark modes.
+## 2026-07-10 - Scoping interactive CSS properties on shared components
+**Learning:** When styling custom components that mix static and interactive variants (e.g., `.card-header`), applying interactive CSS properties like `cursor: grab` or `:focus-visible` globally creates misleading visual affordances on static elements.
+**Action:** Always scope interactive CSS properties to functional attributes (like `[data-bs-toggle="collapse"]`) to avoid confusing users with interactive indicators on non-interactive components.

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -9,13 +9,13 @@
     border-radius: 5px;
 }
 
-.card-header {
+.card-header[data-bs-toggle="collapse"] {
     cursor: move;
     cursor: grab;
     position: relative;
 }
 
-.card-header:active {
+.card-header[data-bs-toggle="collapse"]:active {
     cursor: grabbing;
 }
 
@@ -30,12 +30,12 @@
     border: 2px dashed #0d6efd;
 }
 
-.card-header:focus-visible {
+.card-header[data-bs-toggle="collapse"]:focus-visible {
     outline: 2px solid #0d6efd;
     outline-offset: -2px;
 }
 
-.card-header .caret {
+.card-header[data-bs-toggle="collapse"] .caret {
     position: absolute;
     right: 1rem;
     top: 50%;


### PR DESCRIPTION
**💡 What:** 
Scoped interactive CSS properties (like `cursor: move`, `cursor: grabbing`, and `:focus-visible` outlines) exclusively to `.card-header` elements that possess the `data-bs-toggle="collapse"` attribute.

**🎯 Why:**
Previously, *all* `.card-header` elements received a `grab` cursor and custom focus outlines. This created a confusing, misleading visual affordance on static cards (like the "Controls" card on the side), tricking users into thinking they could drag or collapse it.

**📸 Before/After:**
*Before:* Hovering over the "Controls" header showed a grabbing hand icon, but it couldn't be dragged or clicked.
*After:* Hovering over the "Controls" header shows a standard arrow pointer, while hovering over the "Charts" or "Logs" headers correctly shows the grabbing hand.

**♿ Accessibility:**
Removes confusing focus states from static elements, streamlining keyboard navigation and preventing users from interacting with dead UI elements.

---
*PR created automatically by Jules for task [17968804337881014522](https://jules.google.com/task/17968804337881014522) started by @brewmarsh*