### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix authorization bypass via spoofed headers

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -101,8 +101,6 @@ class IPWhitelistMiddleware(BaseHTTPMiddleware):
                 elif request.headers.get("X-Real-IP"):
                     client_ip_str = request.headers.get("X-Real-IP").strip()
 
-            if client_ip_str == "testclient":
-                client_ip_str = "127.0.0.1"
             try:
                 client_ip = ip_address(client_ip_str)
             except ValueError:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `IPWhitelistMiddleware` contained a hardcoded IP rewrite where if a request provided an IP (e.g., via `X-Forwarded-For` or `X-Real-IP`) set to `"testclient"`, it would automatically rewrite the client's IP to `"127.0.0.1"`.
🎯 Impact: An attacker could bypass the IP whitelist authorization completely by spoofing their headers and injecting `"testclient"`, tricking the system into treating the request as originating from localhost (which is typically allowed).
🔧 Fix: Removed the `testclient` hardcoded condition from the production middleware. In FastAPI tests, the client IP should be properly set in the `TestClient` initialization (e.g., `TestClient(app, client=("127.0.0.1", 12345))`), which is the standard mechanism and is already being correctly utilized in the test suite.
✅ Verification: Ran the full test suite (`poetry run pytest`), confirming that removing this backdoor does not cause regressions and that middleware security tests continue to pass appropriately.

---
*PR created automatically by Jules for task [3222462953177582172](https://jules.google.com/task/3222462953177582172) started by @brewmarsh*