### PR TITLE
🎨 Palette: Scope interactive visual affordances on card headers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2026-07-07 - Visual Feedback for Drag and Drop operations
 **Learning:** By default, libraries like Sortable.js handle the DOM reordering but provide little out-of-the-box visual feedback during the actual drag operation, which can leave users confused about where an element will drop.
 **Action:** Always provide CSS styling for the `sortable-ghost` (or equivalent) class provided by drag-and-drop libraries to visually indicate the drop zone (e.g., using lowered opacity and dashed borders), and update the cursor states (`grab` and `grabbing`) on the drag handles to improve interaction clarity. Ensure these styles are tested in both light and dark modes.
+
+## 2024-05-14 - Scoping Interactive Visual Affordances
+**Learning:** Applying interactive CSS properties (like `cursor: grab`, `:active`, or `:focus-visible`) to broad structural classes (like `.card-header`) often leads to static elements receiving misleading visual affordances, confusing users about what is actually interactive.
+**Action:** Always scope interactive visual affordances in CSS to functional HTML attributes (e.g., `[data-bs-toggle="collapse"]` or `[role="button"]`) rather than structural classes, ensuring only genuinely interactive variants of a component look interactive.

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -10,12 +10,15 @@
 }
 
 .card-header {
-    cursor: move;
-    cursor: grab;
     position: relative;
 }
 
-.card-header:active {
+.card-header[data-bs-toggle="collapse"] {
+    cursor: move;
+    cursor: grab;
+}
+
+.card-header[data-bs-toggle="collapse"]:active {
     cursor: grabbing;
 }
 
@@ -30,12 +33,12 @@
     border: 2px dashed #0d6efd;
 }
 
-.card-header:focus-visible {
+.card-header[data-bs-toggle="collapse"]:focus-visible {
     outline: 2px solid #0d6efd;
     outline-offset: -2px;
 }
 
-.card-header .caret {
+.card-header[data-bs-toggle="collapse"] .caret {
     position: absolute;
     right: 1rem;
     top: 50%;


### PR DESCRIPTION
💡 **What:** Scoped the CSS rules defining interactive visual states (`cursor: grab`, `:active` and `:focus-visible`) on `.card-header` to only apply when the element possesses the `data-bs-toggle="collapse"` attribute.

🎯 **Why:** Previously, the interactive visual states were applied globally to all `.card-header` elements. This caused confusion because static card headers (like the "Controls" card on the sidebar) showed a grab cursor when hovered over, leading users to believe they could interact with or collapse it, even when it wasn't interactive.

♿ **Accessibility:** Prevents users—especially cognitive accessibility users who rely heavily on precise visual feedback—from being confused or frustrated by "phantom" interactive elements that do not actually function as buttons.

---
*PR created automatically by Jules for task [13678887979795096038](https://jules.google.com/task/13678887979795096038) started by @brewmarsh*