### PR TITLE
⚡ Bolt: [performance improvement] Move static inner helper functions to module level

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2025-10-25 - Prevent N+1 API calls in SSE streams
 **Learning:** Making live external API calls (e.g. `get_mappings_data`) inside a Server-Sent Events (SSE) `while True` loop can cause an N+1 query problem per connected client, leading to excessive API requests, rate limiting, and thread blocking.
 **Action:** Always read data from a background-updated local cache (e.g. `cache.json` updated by a separate daemon) rather than making direct, live API requests inside the stream loop to prevent N+1 issues in SSE streams.
+
+## 2025-10-26 - Static inner helper functions in SSE streams
+**Learning:** Defining static inner helper functions (like `read_sync_log` and `read_changelog`) inside a Server-Sent Events (SSE) generator function creates unnecessary function re-definition overhead for every single SSE connection, using excess memory and CPU.
+**Action:** When a helper function inside an endpoint scope does not depend on local closure variables (like the request object), define it at the module level to avoid re-defining it repeatedly per connected client.

--- a/app/app.py
+++ b/app/app.py
@@ -3,6 +3,7 @@ import json
 import os
 import threading
 import time
+from collections import deque
 from contextlib import asynccontextmanager
 from ipaddress import ip_address, ip_network
 from pathlib import Path
@@ -161,7 +162,6 @@ async def update_pihole(request: Request):
 async def check_pihole_error(request: Request):
     log_file = Path('/app/logs/sync.log')
     if log_file.exists():
-        from collections import deque
         with log_file.open("r") as f:
             # 🛡️ Sentinel: Prevent Memory Exhaustion DoS by limiting read
             log_content = "".join(deque(f, maxlen=1000))
@@ -169,34 +169,35 @@ async def check_pihole_error(request: Request):
             return JSONResponse(content={"error": "forbidden"})
     return JSONResponse(content={})
 
+# ⚡ Bolt Optimization: Moved inner functions _read_sync_log and _read_changelog to the module level
+# Impact: Prevents unnecessary function re-definition overhead per SSE connection, saving memory and CPU per client loop.
+# Measurement: Inspect memory usage and request parsing times when hundreds of clients connect concurrently.
+def _read_sync_log():
+    log_file = Path('/app/logs/sync.log')
+    if not log_file.exists():
+        log_file.touch()
+    with log_file.open("r") as f:
+        # 🛡️ Sentinel: Prevent Memory Exhaustion DoS by limiting read
+        return "".join(deque(f, maxlen=1000))
+
+def _read_changelog():
+    changelog_file = Path('/app/changelog.log')
+    if not changelog_file.exists():
+        changelog_file.touch()
+    with changelog_file.open("r") as f:
+        # 🛡️ Sentinel: Prevent Memory Exhaustion DoS by limiting read
+        return "".join(deque(f, maxlen=1000))
+
 @app.get("/stream")
 @limiter.limit(get_rate_limit)
 async def stream(request: Request):
     async def event_stream():
-        def read_sync_log():
-            log_file = Path('/app/logs/sync.log')
-            if not log_file.exists():
-                log_file.touch()
-            from collections import deque
-            with log_file.open("r") as f:
-                # 🛡️ Sentinel: Prevent Memory Exhaustion DoS by limiting read
-                return "".join(deque(f, maxlen=1000))
-
-        def read_changelog():
-            changelog_file = Path('/app/changelog.log')
-            if not changelog_file.exists():
-                changelog_file.touch()
-            from collections import deque
-            with changelog_file.open("r") as f:
-                # 🛡️ Sentinel: Prevent Memory Exhaustion DoS by limiting read
-                return "".join(deque(f, maxlen=1000))
-
         while True:
             try:
-                log_content = await asyncio.to_thread(read_sync_log)
+                log_content = await asyncio.to_thread(_read_sync_log)
                 yield f"data: {json.dumps({'log': log_content})}\n\n"
 
-                changelog_content = await asyncio.to_thread(read_changelog)
+                changelog_content = await asyncio.to_thread(_read_changelog)
                 yield f"data: {json.dumps({'changelog': changelog_content})}\n\n"
 
                 mappings = await asyncio.to_thread(get_mappings_data)
@@ -335,7 +336,6 @@ async def health_check(request: Request):
 async def get_history(request: Request):
     """Returns the history of the number of mapped devices."""
     try:
-        from collections import deque
         with Path("/app/history.log").open("r") as f:
             # 🛡️ Sentinel: Prevent Memory Exhaustion DoS by limiting read
             history = list(deque(f, maxlen=1000))


### PR DESCRIPTION
💡 **What**: Hoisted the `_read_sync_log` and `_read_changelog` helper functions in the `/stream` endpoint to the module level.
🎯 **Why**: Because they were defined inside the `event_stream()` SSE generator function, Python had to redefine these functions in memory on every single SSE connection. This causes unnecessary CPU/memory overhead per client. Furthermore, the local `from collections import deque` imports were executed on every while-loop iteration, which triggers dictionary lookups in `sys.modules` continuously. 
📊 **Impact**: Saves memory and CPU overhead per client loop. Prevents `deque` local import overhead on every single tick of the SSE loop for every connected client.
🔬 **Measurement**: Inspect memory usage and request parsing times when hundreds of clients connect concurrently.

---
*PR created automatically by Jules for task [14376435448341008834](https://jules.google.com/task/14376435448341008834) started by @brewmarsh*