### PR TITLE
🎨 Palette: Add accessible required indicator to Sync Interval input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -32,3 +32,7 @@
 ## 2024-05-14 - Scoping Interactive Visual Affordances
 **Learning:** Applying interactive CSS properties (like `cursor: grab`, `:active`, or `:focus-visible`) to broad structural classes (like `.card-header`) often leads to static elements receiving misleading visual affordances, confusing users about what is actually interactive.
 **Action:** Always scope interactive visual affordances in CSS to functional HTML attributes (e.g., `[data-bs-toggle="collapse"]` or `[role="button"]`) rather than structural classes, ensuring only genuinely interactive variants of a component look interactive.
+
+## 2024-07-12 - Accessible Visual Indicators for Required Form Fields
+**Learning:** When using standard `required` HTML attributes on form fields, users—and especially screen reader users—need clear indication *before* submission that the field is mandatory. A red asterisk is a common visual convention, but screen readers may mispronounce or ignore it if not tagged correctly.
+**Action:** Always wrap visual indicators like asterisks with `aria-hidden="true"` and supplement them with explicit `<span class="visually-hidden"> (required)</span>` text within the `<label>` to ensure both sighted and screen-reader users understand the requirement.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -161,7 +161,7 @@
                         </div>
                         <hr>
                         <div class="mb-3">
-                            <label for="sync-interval" class="form-label">Sync Interval (seconds)</label>
+                            <label for="sync-interval" class="form-label">Sync Interval (seconds) <span class="text-danger" aria-hidden="true">*</span><span class="visually-hidden"> (required)</span></label>
                             <div class="input-group">
                                 <input type="number" class="form-control" id="sync-interval" min="1" max="86400" value="{{ sync_interval }}" aria-describedby="sync-interval-help" required>
                                 <button class="btn btn-outline-secondary" id="update-interval" aria-label="Update sync interval">Update</button>


### PR DESCRIPTION
💡 What: Added an accessible visual required indicator to the Sync Interval input label.
🎯 Why: The `sync-interval` input is marked as `required`, but there was no visual or semantic indication to users before submission.
📸 Before/After: Sighted users now see a standard red `*` next to the label.
♿ Accessibility: The red `*` is hidden from screen readers using `aria-hidden="true"`, and a visually hidden `(required)` text was added to properly announce the requirement to screen reader users.

---
*PR created automatically by Jules for task [2997156171916984900](https://jules.google.com/task/2997156171916984900) started by @brewmarsh*