### PR TITLE
🎨 Palette: Enhance Welcome Screen Modal Dismissal UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -36,3 +36,7 @@
 ## 2024-07-12 - Accessible Visual Indicators for Required Form Fields
 **Learning:** When using standard `required` HTML attributes on form fields, users—and especially screen reader users—need clear indication *before* submission that the field is mandatory. A red asterisk is a common visual convention, but screen readers may mispronounce or ignore it if not tagged correctly.
 **Action:** Always wrap visual indicators like asterisks with `aria-hidden="true"` and supplement them with explicit `<span class="visually-hidden"> (required)</span>` text within the `<label>` to ensure both sighted and screen-reader users understand the requirement.
+
+## 2024-07-14 - Custom Modal Overlay Dismissal Pattern
+**Learning:** When building custom modal overlays without native `<dialog>` or framework components (like Bootstrap `.modal`), users expect standard dismissal interactions such as pressing the `Escape` key and clicking on the backdrop (outside the main modal content). Omitting these interactions degrades UX and creates accessibility friction for keyboard users.
+**Action:** Always implement explicit event listeners for the `Escape` key and background (backdrop) clicks to provide standard accessibility and UX dismissal patterns when creating custom modals or overlays.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -452,15 +452,35 @@
             }
             document.getElementById('loading-screen').style.display = 'none';
 
-            if (!localStorage.getItem('welcomeScreenSeen')) {
-                document.getElementById('welcome-screen').style.display = 'flex';
-                document.getElementById('close-welcome-screen').focus();
-            }
+            const welcomeScreen = document.getElementById('welcome-screen');
+            if (welcomeScreen) {
+                if (!localStorage.getItem('welcomeScreenSeen')) {
+                    welcomeScreen.style.display = 'flex';
+                    document.getElementById('close-welcome-screen').focus();
+                }
 
-            document.getElementById('close-welcome-screen').addEventListener('click', () => {
-                document.getElementById('welcome-screen').style.display = 'none';
-                localStorage.setItem('welcomeScreenSeen', 'true');
-            });
+                const closeWelcomeScreen = () => {
+                    welcomeScreen.style.display = 'none';
+                    localStorage.setItem('welcomeScreenSeen', 'true');
+                };
+
+                const closeBtn = document.getElementById('close-welcome-screen');
+                if (closeBtn) {
+                    closeBtn.addEventListener('click', closeWelcomeScreen);
+                }
+
+                welcomeScreen.addEventListener('click', (e) => {
+                    if (e.target === welcomeScreen) {
+                        closeWelcomeScreen();
+                    }
+                });
+
+                document.addEventListener('keydown', (e) => {
+                    if (e.key === 'Escape' && welcomeScreen.style.display === 'flex') {
+                        closeWelcomeScreen();
+                    }
+                });
+            }
 
             fetch('/cache')
                 .then(response => response.json())


### PR DESCRIPTION
💡 **What**: Added standard modal dismissal interactions (Escape key and backdrop click) to the custom `#welcome-screen` overlay.

🎯 **Why**: Users expect custom modals and overlays to behave like standard dialogs. Providing standard dismissal methods makes the interface more intuitive and prevents users from feeling trapped.

📸 **Before/After**: The visual appearance of the modal itself is unchanged, but the interaction model is greatly improved. Previously, the only way to dismiss the welcome screen was by clicking the explicit "Get Started" button. Now, users can tap Escape or click outside the main card.

♿ **Accessibility**: Significant improvement for keyboard navigation, allowing screen reader and keyboard-only users to easily dismiss the overlay without having to locate and focus the explicit close button first.

---
*PR created automatically by Jules for task [11359364072961255646](https://jules.google.com/task/11359364072961255646) started by @brewmarsh*