### PR TITLE
⚡ Bolt: Read mappings from local cache file instead of live API

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 ## 2024-07-12 - Redundant Backend Polling in SSE Handlers
 **Learning:** In frontend applications listening to Server-Sent Events (SSE), it is a performance anti-pattern to trigger separate HTTP polling requests (e.g., `fetch()`) to check for a specific state or error if the data required to determine that state is already included in the SSE payload itself.
 **Action:** Always verify if the necessary data is already available in the SSE message stream (e.g., checking `data.log.includes(...)`) to eliminate redundant HTTP requests, reduce server load, and lower memory footprint by removing unnecessary API endpoints.
+
+## 2026-07-14 - Remove unused API fetching helpers after cache refactor
+**Learning:** When refactoring an endpoint to read from a local cache file instead of live API queries, check if the previously used helper methods are now completely unused.
+**Action:** Always delete now-unused helper functions (like `_get_pihole_data` and `_get_meraki_data`) to reduce memory footprint and improve code maintainability, and clean up the associated imports.

--- a/app/app.py
+++ b/app/app.py
@@ -9,7 +9,6 @@ from ipaddress import ip_address, ip_network
 from pathlib import Path
 
 import markdown
-import meraki
 import structlog
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
@@ -22,9 +21,7 @@ from slowapi.util import get_remote_address
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
-from .clients.meraki_client import get_all_relevant_meraki_clients
-from .clients.pihole_client import PiholeClient
-from .sync_logic import get_sync_interval, load_app_config_from_env
+from .sync_logic import get_sync_interval
 from .sync_logic import sync_pihole_dns as run_sync_main
 
 log = structlog.get_logger()
@@ -199,28 +196,6 @@ async def stream(request: Request):
 
     return StreamingResponse(event_stream(), media_type='text/event-stream')
 
-def _get_pihole_data(pihole_url, pihole_api_key):
-    client = PiholeClient(pihole_url, pihole_api_key)
-    if not client.sid:
-        log.error("Failed to authenticate to Pi-hole in _get_pihole_data.")
-        return None, None
-
-    pihole_records = client.get_custom_dns_records()
-    if pihole_records is None:
-        log.error("Failed to get Pi-hole records in _get_pihole_data.")
-        return None, None
-
-    return client.sid, pihole_records
-
-def _get_meraki_data(config):
-    dashboard = meraki.DashboardAPI(
-        api_key=config["meraki_api_key"],
-        output_log=False,
-        print_console=False,
-        suppress_logging=True,
-    )
-    return get_all_relevant_meraki_clients(dashboard, config)
-
 def _map_devices(meraki_clients, pihole_records):
     mapped_devices = []
     unmapped_meraki_devices = []
@@ -258,21 +233,21 @@ def get_mappings_data():
         return _mappings_cache
 
     try:
-        config = load_app_config_from_env()
-        pihole_url = os.getenv("PIHOLE_API_URL")
-        pihole_api_key = os.getenv("PIHOLE_API_KEY")
+        with Path("/app/cache.json").open() as f:
+            cache = json.load(f)
 
-        sid, pihole_records = _get_pihole_data(pihole_url, pihole_api_key)
-        if not sid:
-            return {}
+        pihole_records = cache.get("pihole", {})
+        meraki_clients = cache.get("meraki", [])
 
-        meraki_clients = _get_meraki_data(config)
         mapped_devices, unmapped_meraki_devices = _map_devices(meraki_clients, pihole_records)
 
         result = {"pihole": pihole_records, "meraki": meraki_clients, "mapped": mapped_devices, "unmapped_meraki": unmapped_meraki_devices}
         _mappings_cache = result
         _mappings_cache_time = time.time()
         return result
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        log.warning("Cache file not available or invalid mid-write", error=e)
+        return {}
     except Exception as e:
         log.error("Error in get_mappings_data", error=e)
         return {}

--- a/app/sync_logic.py
+++ b/app/sync_logic.py
@@ -111,25 +111,6 @@ def get_meraki_data(config):
     return get_all_relevant_meraki_clients(dashboard, config)
 
 
-def get_mappings_data():
-    """
-    Gets the data for the mappings page.
-    """
-    try:
-        config = load_app_config_from_env()
-        pihole_client = PiholeClient(config["pihole_api_url"], config["pihole_api_key"])
-        pihole_records = pihole_client.get_custom_dns_records()
-        if not pihole_records:
-            return {}
-
-        meraki_clients = get_meraki_data(config)
-        mapped_devices, unmapped_meraki_devices = map_devices(meraki_clients, pihole_records)
-
-        return {"pihole": pihole_records, "meraki": meraki_clients, "mapped": mapped_devices, "unmapped_meraki": unmapped_meraki_devices}
-    except Exception as e:
-        log.error("Error in get_mappings_data", error=e)
-        return {}
-
 def map_devices(meraki_clients, pihole_records):
     """
     Maps Meraki clients to Pi-hole records.


### PR DESCRIPTION
💡 What: Refactored `get_mappings_data` in `app/app.py` to read mappings data directly from the background-synced `cache.json` rather than falling back to live Meraki and Pi-hole API calls. Also deleted the now-unused inner helpers `_get_pihole_data` and `_get_meraki_data` from `app/app.py`.
🎯 Why: Live external API calls inside Server-Sent Events streams (even when falling back from a TTL cache) caused thread-blocking and N+1 query problems. By utilizing the `cache.json` which is already being written by the daemon `sync_logic.py`, we prevent synchronous API queries from rendering in endpoints entirely.
📊 Impact: Prevents N+1 HTTP polling behavior within SSE stream, significantly lowering server load, and avoids blocking worker threads by performing rapid disk read instead of network I/O.
🔬 Measurement: Compare API request logs during active SSE connections with multiple frontend clients.

---
*PR created automatically by Jules for task [17189410156488164241](https://jules.google.com/task/17189410156488164241) started by @brewmarsh*