### PR TITLE
🛡️ Sentinel: [HIGH] Fix rate limiting IP spoofing bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** A hardcoded `client_ip_str == "testclient"` check was left in production middleware, allowing any attacker to bypass IP whitelisting by passing headers like `X-Forwarded-For: testclient` which would then be authorized as `127.0.0.1`.
 **Learning:** Testing shortcuts left in production code create critical security vulnerabilities, particularly when combined with proxy header trusting where the client string can be fully spoofed.
 **Prevention:** Never leave backdoor strings for testing in production security logic. In FastAPI testing, use the `client` argument in `TestClient(app, client=('127.0.0.1', 12345))` to properly mock the request client IP instead.
+## 2026-07-15 - Fix SlowAPI Proxy Bypass
+**Vulnerability:** IP spoofing bypass behind reverse proxies due to relying on `slowapi.util.get_remote_address` which trusts proxy headers unconditionally.
+**Learning:** Default IP extraction functions in rate limiting libraries (like `get_remote_address` in slowapi) often trust `X-Forwarded-For` unconditionally or are misconfigured for environments where the application might not always be behind a proxy, allowing an attacker to bypass rate limits by spoofing the header.
+**Prevention:** Always provide a custom `key_func` to rate limiters that securely handles client IP extraction based on explicit configuration (like `TRUST_REVERSE_PROXY`), matching the logic used in authorization middleware.

--- a/app/app.py
+++ b/app/app.py
@@ -18,7 +18,6 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_remote_address
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
@@ -32,7 +31,20 @@ log = structlog.get_logger()
 def get_rate_limit():
     return os.getenv("RATE_LIMIT", "100/minute")
 
-limiter = Limiter(key_func=get_remote_address)
+def get_remote_ip(request: Request) -> str:
+    """
+    🛡️ Sentinel: Securely extract client IP for rate limiting.
+    Prevents IP spoofing via X-Forwarded-For when TRUST_REVERSE_PROXY is not true.
+    """
+    if os.getenv("TRUST_REVERSE_PROXY", "false").lower() == "true":
+        forwarded_for = request.headers.get("X-Forwarded-For")
+        if forwarded_for:
+            return forwarded_for.split(",")[-1].strip()
+        elif request.headers.get("X-Real-IP"):
+            return request.headers.get("X-Real-IP").strip()
+    return request.client.host if request.client else "127.0.0.1"
+
+limiter = Limiter(key_func=get_remote_ip)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: The `slowapi.util.get_remote_address` function blindly trusts the `X-Forwarded-For` header, allowing attackers to spoof their IP address to bypass rate limits.
* 🎯 Impact: Attackers could exhaust resources and bypass rate limit protections by spoofing headers.
* 🔧 Fix: Implemented a custom `get_remote_ip` key function for the rate limiter that securely checks the right-most `X-Forwarded-For` IP only when `TRUST_REVERSE_PROXY` is enabled.
* ✅ Verification: Ran tests (`poetry run pytest`), linting (`poetry run ruff check`), and successfully verified the code structure with `git diff`.

---
*PR created automatically by Jules for task [8827419803600553588](https://jules.google.com/task/8827419803600553588) started by @brewmarsh*