### PR TITLE
🎨 Palette: Add Escape key and backdrop dismissal to welcome modal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -36,3 +36,6 @@
 ## 2024-07-12 - Accessible Visual Indicators for Required Form Fields
 **Learning:** When using standard `required` HTML attributes on form fields, users—and especially screen reader users—need clear indication *before* submission that the field is mandatory. A red asterisk is a common visual convention, but screen readers may mispronounce or ignore it if not tagged correctly.
 **Action:** Always wrap visual indicators like asterisks with `aria-hidden="true"` and supplement them with explicit `<span class="visually-hidden"> (required)</span>` text within the `<label>` to ensure both sighted and screen-reader users understand the requirement.
+## 2024-07-24 - Custom Modal Dismissal Patterns
+**Learning:** When building custom modal overlays without native `<dialog>` or framework components, lacking standard keyboard and mouse dismissal patterns creates a poor UX and accessibility barrier, trapping users who expect standard behaviors.
+**Action:** Always implement explicit event listeners for the `Escape` key (`keydown`) and background (backdrop) clicks to provide standard dismissal patterns for custom modals.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -452,15 +452,31 @@
             }
             document.getElementById('loading-screen').style.display = 'none';
 
-            if (!localStorage.getItem('welcomeScreenSeen')) {
-                document.getElementById('welcome-screen').style.display = 'flex';
-                document.getElementById('close-welcome-screen').focus();
-            }
+            const welcomeScreen = document.getElementById('welcome-screen');
+            if (welcomeScreen) {
+                const dismissWelcomeScreen = () => {
+                    welcomeScreen.style.display = 'none';
+                    localStorage.setItem('welcomeScreenSeen', 'true');
+                };
 
-            document.getElementById('close-welcome-screen').addEventListener('click', () => {
-                document.getElementById('welcome-screen').style.display = 'none';
-                localStorage.setItem('welcomeScreenSeen', 'true');
-            });
+                if (!localStorage.getItem('welcomeScreenSeen')) {
+                    welcomeScreen.style.display = 'flex';
+                    const closeBtn = document.getElementById('close-welcome-screen');
+                    if (closeBtn) closeBtn.focus();
+                }
+
+                document.getElementById('close-welcome-screen').addEventListener('click', dismissWelcomeScreen);
+
+                welcomeScreen.addEventListener('click', (e) => {
+                    if (e.target === welcomeScreen) dismissWelcomeScreen();
+                });
+
+                document.addEventListener('keydown', (e) => {
+                    if (e.key === 'Escape' && welcomeScreen.style.display === 'flex') {
+                        dismissWelcomeScreen();
+                    }
+                });
+            }
 
             fetch('/cache')
                 .then(response => response.json())


### PR DESCRIPTION
💡 **What**: Added `Escape` key and background (backdrop) click event listeners to the `#welcome-screen` modal to dismiss it.
🎯 **Why**: Custom modal overlays that lack standard keyboard and mouse dismissal patterns create a poor UX and trap users who intuitively try to click away or press Escape to close them.
📸 **Before/After**: Before, the user had to click exactly on the "Get Started" button to close the modal. After, clicking the dark background or pressing the Escape key also dismisses it.
♿ **Accessibility**: Improves keyboard accessibility by providing a standard, expected keystroke (`Escape`) to dismiss an intrusive overlay.

---
*PR created automatically by Jules for task [2686994729412844471](https://jules.google.com/task/2686994729412844471) started by @brewmarsh*