### PR TITLE
🎨 Palette: Add keyboard and backdrop dismissal to welcome modal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -36,3 +36,7 @@
 ## 2024-07-12 - Accessible Visual Indicators for Required Form Fields
 **Learning:** When using standard `required` HTML attributes on form fields, users—and especially screen reader users—need clear indication *before* submission that the field is mandatory. A red asterisk is a common visual convention, but screen readers may mispronounce or ignore it if not tagged correctly.
 **Action:** Always wrap visual indicators like asterisks with `aria-hidden="true"` and supplement them with explicit `<span class="visually-hidden"> (required)</span>` text within the `<label>` to ensure both sighted and screen-reader users understand the requirement.
+
+## 2024-05-24 - Add keyboard/backdrop dismissal to custom modal
+**Learning:** When building custom modal overlays without native `<dialog>` or framework components (like Bootstrap `.modal`), standard accessibility and UX dismissal patterns (Escape key and background/backdrop clicks) must be explicitly implemented to ensure the element can be intuitively dismissed by users. Also ensure checking for existence of elements before adding listeners.
+**Action:** Always verify keyboard and backdrop dismiss patterns for newly created custom modals, and safely check if the DOM elements exist in case they're conditionally rendered.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -452,15 +452,35 @@
             }
             document.getElementById('loading-screen').style.display = 'none';
 
-            if (!localStorage.getItem('welcomeScreenSeen')) {
-                document.getElementById('welcome-screen').style.display = 'flex';
-                document.getElementById('close-welcome-screen').focus();
-            }
+            const welcomeScreen = document.getElementById('welcome-screen');
+            const closeWelcomeBtn = document.getElementById('close-welcome-screen');
 
-            document.getElementById('close-welcome-screen').addEventListener('click', () => {
-                document.getElementById('welcome-screen').style.display = 'none';
-                localStorage.setItem('welcomeScreenSeen', 'true');
-            });
+            if (welcomeScreen && closeWelcomeBtn) {
+                if (!localStorage.getItem('welcomeScreenSeen')) {
+                    welcomeScreen.style.display = 'flex';
+                    closeWelcomeBtn.focus();
+                }
+
+                const hideWelcomeScreen = () => {
+                    welcomeScreen.style.display = 'none';
+                    localStorage.setItem('welcomeScreenSeen', 'true');
+                };
+
+                closeWelcomeBtn.addEventListener('click', hideWelcomeScreen);
+
+                // Add standard modal dismissal patterns
+                welcomeScreen.addEventListener('click', (e) => {
+                    if (e.target === welcomeScreen) {
+                        hideWelcomeScreen();
+                    }
+                });
+
+                document.addEventListener('keydown', (e) => {
+                    if (e.key === 'Escape' && welcomeScreen.style.display === 'flex') {
+                        hideWelcomeScreen();
+                    }
+                });
+            }
 
             fetch('/cache')
                 .then(response => response.json())


### PR DESCRIPTION
**💡 What:** 
Added standard modal dismissal interactions (listening for the `Escape` key and clicks on the modal backdrop) to the custom `#welcome-screen` overlay.

**🎯 Why:**
When a custom modal overlay is displayed, standard usability conventions expect users to be able to dismiss it either by pressing the Escape key or clicking outside of it (the backdrop). Without this, users who accidentally trigger the overlay or naturally reach for these common interactions would find the UI unresponsive or trapping.

**📸 Before/After:**
- **Before:** The modal could only be dismissed by explicitly clicking the "Get Started" close button.
- **After:** The modal can be dismissed using the close button, clicking anywhere on the dark backdrop, or pressing the `Escape` key on the keyboard.

**♿ Accessibility:**
This change provides standard keyboard support (`Escape` key) to dismiss the overlay, ensuring keyboard users do not have to manually tab to the close button if they want to quickly escape the context of the modal. It also adds a null-safety check for the elements since they are conditionally rendered via Jinja template logic.

---
*PR created automatically by Jules for task [15012624719596879376](https://jules.google.com/task/15012624719596879376) started by @brewmarsh*