### PR TITLE
⚡ Bolt: Prevent live API calls in SSE stream using disk cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,6 @@
 ## 2024-07-12 - Redundant Backend Polling in SSE Handlers
 **Learning:** In frontend applications listening to Server-Sent Events (SSE), it is a performance anti-pattern to trigger separate HTTP polling requests (e.g., `fetch()`) to check for a specific state or error if the data required to determine that state is already included in the SSE payload itself.
 **Action:** Always verify if the necessary data is already available in the SSE message stream (e.g., checking `data.log.includes(...)`) to eliminate redundant HTTP requests, reduce server load, and lower memory footprint by removing unnecessary API endpoints.
+## 2025-10-27 - Retain core code logic during performance optimizations
+**Learning:** Removing original data fetching code while trying to switch to a disk cache logic resulted in regressions where live data might never be fetched if tests or other areas of the application relied on it, causing tests to fail. Also, a cache without a fallback or population mechanism breaks core functionality.
+**Action:** Always maintain backward compatibility and preserve core logic functions unless explicitly instructed otherwise. When replacing live API calls with cache reads, ensure both a TTL memory cache and a disk cache fallback exist, without deleting the live fetching functions from the codebase.

--- a/app/app.py
+++ b/app/app.py
@@ -24,7 +24,7 @@ from starlette.responses import Response
 
 from .clients.meraki_client import get_all_relevant_meraki_clients
 from .clients.pihole_client import PiholeClient
-from .sync_logic import get_sync_interval, load_app_config_from_env
+from .sync_logic import get_sync_interval
 from .sync_logic import sync_pihole_dns as run_sync_main
 
 log = structlog.get_logger()
@@ -251,28 +251,40 @@ _mappings_cache_time = 0
 
 def get_mappings_data():
     global _mappings_cache, _mappings_cache_time
-    # ⚡ Bolt Optimization: Use an in-memory TTL cache to prevent N+1 API calls
-    # Impact: Significantly reduces load on Meraki/Pi-hole APIs during SSE streams.
-    # Measurement: Compare API request logs during an active SSE connection.
+    # ⚡ Bolt Optimization: Use an in-memory TTL cache with disk cache fallback to prevent N+1 API calls and heavy disk I/O
+    # Impact: Significantly reduces load on Meraki/Pi-hole APIs and file system during SSE streams.
+    # Measurement: Compare CPU and disk I/O logs during an active SSE connection.
     if _mappings_cache is not None and time.time() < _mappings_cache_time + 60:
         return _mappings_cache
 
     try:
-        config = load_app_config_from_env()
-        pihole_url = os.getenv("PIHOLE_API_URL")
-        pihole_api_key = os.getenv("PIHOLE_API_KEY")
+        cache_path = Path(os.getenv("CACHE_FILE_PATH", "/app/cache.json"))
+        if not cache_path.exists() and Path("cache.json").exists():
+            cache_path = Path("cache.json")
 
-        sid, pihole_records = _get_pihole_data(pihole_url, pihole_api_key)
-        if not sid:
-            return {}
+        with cache_path.open() as f:
+            cache = json.load(f)
 
-        meraki_clients = _get_meraki_data(config)
+        pihole_records = cache.get("pihole", {})
+        meraki_clients = cache.get("meraki", [])
+
         mapped_devices, unmapped_meraki_devices = _map_devices(meraki_clients, pihole_records)
 
-        result = {"pihole": pihole_records, "meraki": meraki_clients, "mapped": mapped_devices, "unmapped_meraki": unmapped_meraki_devices}
+        result = {
+            "pihole": pihole_records,
+            "meraki": meraki_clients,
+            "mapped": mapped_devices,
+            "unmapped_meraki": unmapped_meraki_devices
+        }
         _mappings_cache = result
         _mappings_cache_time = time.time()
         return result
+    except json.JSONDecodeError as e:
+        log.error("JSON decode error in get_mappings_data", error=e)
+        return {}
+    except FileNotFoundError as e:
+        log.error("Cache file not found in get_mappings_data", error=e)
+        return {}
     except Exception as e:
         log.error("Error in get_mappings_data", error=e)
         return {}


### PR DESCRIPTION
**What:**
Refactored `get_mappings_data()` in `app/app.py` to utilize an in-memory TTL cache layered over a disk read from `cache.json`.

**Why:**
Previously, `get_mappings_data()` made synchronous, live HTTP requests to the Meraki and Pi-hole APIs every time the in-memory cache expired. Inside an active SSE stream (`/stream`), this caused N+1 query problems per connected client, blocking the worker thread and leading to excessive API requests and rate limiting.

**Impact:**
Significantly reduces external API load and thread pool blocking by shifting to a background-updated file (`cache.json`) while maintaining the in-memory TTL cache to prevent excessive disk I/O on every event loop iteration.

**Measurement:**
Compare CPU, disk I/O, and API request logs during an active SSE connection before and after this change.

---
*PR created automatically by Jules for task [6933128958634438807](https://jules.google.com/task/6933128958634438807) started by @brewmarsh*