### PR TITLE
🎨 Palette: [UX improvement] Add Escape key and backdrop dismissal to welcome screen modal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -36,3 +36,7 @@
 ## 2024-07-12 - Accessible Visual Indicators for Required Form Fields
 **Learning:** When using standard `required` HTML attributes on form fields, users—and especially screen reader users—need clear indication *before* submission that the field is mandatory. A red asterisk is a common visual convention, but screen readers may mispronounce or ignore it if not tagged correctly.
 **Action:** Always wrap visual indicators like asterisks with `aria-hidden="true"` and supplement them with explicit `<span class="visually-hidden"> (required)</span>` text within the `<label>` to ensure both sighted and screen-reader users understand the requirement.
+
+## 2026-07-09 - Accessible Dismissal for Custom Overlays
+**Learning:** When building custom modal overlays without native `<dialog>` or framework components (like Bootstrap `.modal`), users expect standard dismissal patterns such as hitting the `Escape` key or clicking the background backdrop. Missing these patterns creates a frustrating UX, especially for keyboard-only users who might feel "trapped" in the modal.
+**Action:** Always implement explicit event listeners for the `Escape` key and background (backdrop) clicks to provide standard, accessible UX dismissal patterns for any custom overlay or modal.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -452,15 +452,34 @@
             }
             document.getElementById('loading-screen').style.display = 'none';
 
-            if (!localStorage.getItem('welcomeScreenSeen')) {
-                document.getElementById('welcome-screen').style.display = 'flex';
-                document.getElementById('close-welcome-screen').focus();
-            }
+            const welcomeScreen = document.getElementById('welcome-screen');
+            const closeWelcomeBtn = document.getElementById('close-welcome-screen');
 
-            document.getElementById('close-welcome-screen').addEventListener('click', () => {
-                document.getElementById('welcome-screen').style.display = 'none';
-                localStorage.setItem('welcomeScreenSeen', 'true');
-            });
+            if (welcomeScreen && closeWelcomeBtn) {
+                const dismissWelcomeScreen = () => {
+                    welcomeScreen.style.display = 'none';
+                    localStorage.setItem('welcomeScreenSeen', 'true');
+                };
+
+                if (!localStorage.getItem('welcomeScreenSeen')) {
+                    welcomeScreen.style.display = 'flex';
+                    closeWelcomeBtn.focus();
+                }
+
+                closeWelcomeBtn.addEventListener('click', dismissWelcomeScreen);
+
+                document.addEventListener('keydown', (e) => {
+                    if (e.key === 'Escape' && welcomeScreen.style.display === 'flex') {
+                        dismissWelcomeScreen();
+                    }
+                });
+
+                welcomeScreen.addEventListener('click', (e) => {
+                    if (e.target === welcomeScreen) {
+                        dismissWelcomeScreen();
+                    }
+                });
+            }
 
             fetch('/cache')
                 .then(response => response.json())


### PR DESCRIPTION
💡 **What:** Added standard dismissal patterns (Escape key and backdrop clicks) to the custom `#welcome-screen` modal.
🎯 **Why:** To prevent users, especially keyboard-only users, from feeling "trapped" in the modal. It provides standard, expected dismissal behavior without forcing the user to locate and click the specific primary action button.
📸 **Before/After:** The modal now closes when pressing `Escape` or clicking the dark overlay background.
♿ **Accessibility:** Significantly improves keyboard navigation and overall usability by conforming to standard modal dismissal patterns.

---
*PR created automatically by Jules for task [2596044289227030962](https://jules.google.com/task/2596044289227030962) started by @brewmarsh*