### PR TITLE
🛡️ Sentinel: [HIGH] Fix slowapi IP spoofing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** A hardcoded `client_ip_str == "testclient"` check was left in production middleware, allowing any attacker to bypass IP whitelisting by passing headers like `X-Forwarded-For: testclient` which would then be authorized as `127.0.0.1`.
 **Learning:** Testing shortcuts left in production code create critical security vulnerabilities, particularly when combined with proxy header trusting where the client string can be fully spoofed.
 **Prevention:** Never leave backdoor strings for testing in production security logic. In FastAPI testing, use the `client` argument in `TestClient(app, client=('127.0.0.1', 12345))` to properly mock the request client IP instead.
+## 2026-07-17 - Fix slowapi IP Spoofing
+**Vulnerability:** The `slowapi` Limiter was initialized with `key_func=get_remote_address` which, in an environment relying on reverse proxies, does not properly validate or securely extract the actual client IP (such as from `X-Forwarded-For`), leading to potential rate limiting bypass via IP spoofing.
+**Learning:** `slowapi`'s default `get_remote_address` extracts the host connected to the server. If behind a proxy, it will either extract the proxy's IP or, if combined with arbitrary proxy header trusting middleware, might trust attacker-supplied leftmost IPs.
+**Prevention:** Implement a custom `key_func` for the Limiter that extracts the correct, rightmost client IP from the `X-Forwarded-For` chain specifically when configured to trust reverse proxies, unifying this logic with any IP whitelist middleware to ensure consistency.

--- a/app/app.py
+++ b/app/app.py
@@ -18,7 +18,6 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_remote_address
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
@@ -29,10 +28,25 @@ from .sync_logic import sync_pihole_dns as run_sync_main
 
 log = structlog.get_logger()
 
+
+def get_client_ip(request: Request) -> str:
+    # 🛡️ Sentinel: Prevent IP spoofing by only trusting proxy headers if explicitly configured.
+    # When behind a trusted proxy, take the rightmost IP in X-Forwarded-For to avoid spoofing
+    # by attacker-supplied leftmost values.
+    client_ip_str = request.client.host if request.client else "127.0.0.1"
+    if os.getenv("TRUST_REVERSE_PROXY", "false").lower() == "true":
+        forwarded_for = request.headers.get("X-Forwarded-For")
+        if forwarded_for:
+            client_ip_str = forwarded_for.split(",")[-1].strip()
+        elif request.headers.get("X-Real-IP"):
+            client_ip_str = request.headers.get("X-Real-IP").strip()
+    return client_ip_str
+
 def get_rate_limit():
+
     return os.getenv("RATE_LIMIT", "100/minute")
 
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=get_client_ip)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -92,17 +106,7 @@ class IPWhitelistMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         self._parse_subnets()
         if os.getenv("ALLOWED_SUBNETS"):
-            client_ip_str = request.client.host if request.client else "127.0.0.1"
-
-            # 🛡️ Sentinel: Prevent IP spoofing by only trusting proxy headers if explicitly configured.
-            # When behind a trusted proxy, take the rightmost IP in X-Forwarded-For to avoid spoofing
-            # by attacker-supplied leftmost values.
-            if os.getenv("TRUST_REVERSE_PROXY", "false").lower() == "true":
-                forwarded_for = request.headers.get("X-Forwarded-For")
-                if forwarded_for:
-                    client_ip_str = forwarded_for.split(",")[-1].strip()
-                elif request.headers.get("X-Real-IP"):
-                    client_ip_str = request.headers.get("X-Real-IP").strip()
+            client_ip_str = get_client_ip(request)
 
             try:
                 client_ip = ip_address(client_ip_str)


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `slowapi` rate limiter was initialized with `key_func=get_remote_address` which, in an environment relying on reverse proxies, does not properly validate or securely extract the actual client IP (such as from `X-Forwarded-For`), leading to potential rate limiting bypass via IP spoofing.
🎯 Impact: Attackers could spoof their IP address by manipulating the `X-Forwarded-For` headers to bypass rate limits entirely or inadvertently trigger a DoS by getting the reverse proxy's IP rate-limited.
🔧 Fix: Implemented a custom `get_client_ip` function that securely extracts the client IP, falling back on the host or extracting the rightmost IP of the `X-Forwarded-For` chain if explicitly configured to trust the reverse proxy. This function is shared between the `Limiter` and `IPWhitelistMiddleware` to ensure identical interpretation.
✅ Verification: Ran `pytest` testing suite which validates the `IPWhitelistMiddleware` across various mocked header configurations. Evaluated diff logic and verified `slowapi` limiter key initialization properly utilizes the new function.

---
*PR created automatically by Jules for task [9527088107836386731](https://jules.google.com/task/9527088107836386731) started by @brewmarsh*