### PR TITLE
🛡️ Sentinel: [HIGH] Fix rate limit IP spoofing bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** A hardcoded `client_ip_str == "testclient"` check was left in production middleware, allowing any attacker to bypass IP whitelisting by passing headers like `X-Forwarded-For: testclient` which would then be authorized as `127.0.0.1`.
 **Learning:** Testing shortcuts left in production code create critical security vulnerabilities, particularly when combined with proxy header trusting where the client string can be fully spoofed.
 **Prevention:** Never leave backdoor strings for testing in production security logic. In FastAPI testing, use the `client` argument in `TestClient(app, client=('127.0.0.1', 12345))` to properly mock the request client IP instead.
+
+## 2026-07-18 - Fix Rate Limit IP Spoofing bypass
+
+**Vulnerability:** The `slowapi.Limiter` used `get_remote_address` which unconditionally trusts the leftmost IP in the `X-Forwarded-For` chain. An attacker could bypass rate limits by spoofing `X-Forwarded-For` and constantly changing the leftmost IP.
+**Learning:** Default rate limiting implementations often trust proxy headers blindly, leading to trivial IP spoofing bypasses when behind reverse proxies.
+**Prevention:** Unify the secure rightmost IP extraction logic (already used in `IPWhitelistMiddleware`) into a shared `get_client_ip` function and use it as the `key_func` for the rate limiter.

--- a/app/app.py
+++ b/app/app.py
@@ -18,7 +18,6 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_remote_address
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
@@ -32,7 +31,17 @@ log = structlog.get_logger()
 def get_rate_limit():
     return os.getenv("RATE_LIMIT", "100/minute")
 
-limiter = Limiter(key_func=get_remote_address)
+def get_client_ip(request: Request) -> str:
+    client_ip_str = request.client.host if request.client else "127.0.0.1"
+    if os.getenv("TRUST_REVERSE_PROXY", "false").lower() == "true":
+        forwarded_for = request.headers.get("X-Forwarded-For")
+        if forwarded_for:
+            client_ip_str = forwarded_for.split(",")[-1].strip()
+        elif request.headers.get("X-Real-IP"):
+            client_ip_str = request.headers.get("X-Real-IP").strip()
+    return client_ip_str
+
+limiter = Limiter(key_func=get_client_ip)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -92,17 +101,7 @@ class IPWhitelistMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         self._parse_subnets()
         if os.getenv("ALLOWED_SUBNETS"):
-            client_ip_str = request.client.host if request.client else "127.0.0.1"
-
-            # 🛡️ Sentinel: Prevent IP spoofing by only trusting proxy headers if explicitly configured.
-            # When behind a trusted proxy, take the rightmost IP in X-Forwarded-For to avoid spoofing
-            # by attacker-supplied leftmost values.
-            if os.getenv("TRUST_REVERSE_PROXY", "false").lower() == "true":
-                forwarded_for = request.headers.get("X-Forwarded-For")
-                if forwarded_for:
-                    client_ip_str = forwarded_for.split(",")[-1].strip()
-                elif request.headers.get("X-Real-IP"):
-                    client_ip_str = request.headers.get("X-Real-IP").strip()
+            client_ip_str = get_client_ip(request)
 
             try:
                 client_ip = ip_address(client_ip_str)


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `slowapi.Limiter` used the default `get_remote_address` which blindly trusts the leftmost IP in the `X-Forwarded-For` chain. This allows an attacker to trivially bypass rate limits by spoofing the `X-Forwarded-For` header.
🎯 **Impact:** An attacker could bypass rate limits on all endpoints, potentially leading to brute force attacks or Denial of Service.
🔧 **Fix:** Refactored the secure rightmost IP extraction logic (already present in `IPWhitelistMiddleware`) into a shared `get_client_ip` function, and applied it as the `key_func` for both the IP Whitelist and the Rate Limiter.
✅ **Verification:** Verified that tests pass via `poetry run pytest tests/` and linting via `poetry run ruff check`.

---
*PR created automatically by Jules for task [18435110917032412228](https://jules.google.com/task/18435110917032412228) started by @brewmarsh*