### PR TITLE
🛡️ Sentinel: [HIGH] Fix rate limiting IP spoofing bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** A hardcoded `client_ip_str == "testclient"` check was left in production middleware, allowing any attacker to bypass IP whitelisting by passing headers like `X-Forwarded-For: testclient` which would then be authorized as `127.0.0.1`.
 **Learning:** Testing shortcuts left in production code create critical security vulnerabilities, particularly when combined with proxy header trusting where the client string can be fully spoofed.
 **Prevention:** Never leave backdoor strings for testing in production security logic. In FastAPI testing, use the `client` argument in `TestClient(app, client=('127.0.0.1', 12345))` to properly mock the request client IP instead.
+## 2026-07-19 - Fix Rate Limiting IP Spoofing Bypass
+**Vulnerability:** The application used `slowapi`'s default `get_remote_address` for rate limiting, which trusts the `X-Forwarded-For` header and extracts the leftmost IP. When deployed behind a reverse proxy, attackers could spoof their IP by sending a custom `X-Forwarded-For` header, allowing them to bypass rate limiting completely.
+**Learning:** Default rate limiting configurations (like `get_remote_address`) are often unsafe behind reverse proxies because they blindly trust proxy headers and take the leftmost IP which is user-controlled.
+**Prevention:** Implement a custom `key_func` for the Limiter that securely extracts the rightmost IP appended by the trusted proxy and explicitly validates whether `TRUST_REVERSE_PROXY` is enabled.

--- a/app/app.py
+++ b/app/app.py
@@ -18,7 +18,6 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_remote_address
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
@@ -29,10 +28,23 @@ from .sync_logic import sync_pihole_dns as run_sync_main
 
 log = structlog.get_logger()
 
+def get_client_ip(request: Request) -> str:
+    # 🛡️ Sentinel: Prevent IP spoofing by only trusting proxy headers if explicitly configured.
+    # When behind a trusted proxy, take the rightmost IP in X-Forwarded-For to avoid spoofing
+    # by attacker-supplied leftmost values.
+    client_ip_str = request.client.host if request.client else "127.0.0.1"
+    if os.getenv("TRUST_REVERSE_PROXY", "false").lower() == "true":
+        forwarded_for = request.headers.get("X-Forwarded-For")
+        if forwarded_for:
+            client_ip_str = forwarded_for.split(",")[-1].strip()
+        elif request.headers.get("X-Real-IP"):
+            client_ip_str = request.headers.get("X-Real-IP").strip()
+    return client_ip_str
+
 def get_rate_limit():
     return os.getenv("RATE_LIMIT", "100/minute")
 
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=get_client_ip)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -92,17 +104,7 @@ class IPWhitelistMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         self._parse_subnets()
         if os.getenv("ALLOWED_SUBNETS"):
-            client_ip_str = request.client.host if request.client else "127.0.0.1"
-
-            # 🛡️ Sentinel: Prevent IP spoofing by only trusting proxy headers if explicitly configured.
-            # When behind a trusted proxy, take the rightmost IP in X-Forwarded-For to avoid spoofing
-            # by attacker-supplied leftmost values.
-            if os.getenv("TRUST_REVERSE_PROXY", "false").lower() == "true":
-                forwarded_for = request.headers.get("X-Forwarded-For")
-                if forwarded_for:
-                    client_ip_str = forwarded_for.split(",")[-1].strip()
-                elif request.headers.get("X-Real-IP"):
-                    client_ip_str = request.headers.get("X-Real-IP").strip()
+            client_ip_str = get_client_ip(request)
 
             try:
                 client_ip = ip_address(client_ip_str)


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application used `slowapi`'s default `get_remote_address` for rate limiting (`limiter = Limiter(key_func=get_remote_address)`). This function blindly trusts the `X-Forwarded-For` header and extracts the leftmost IP. When deployed behind a reverse proxy, attackers could easily spoof their client IP by sending a custom `X-Forwarded-For` header (e.g., `X-Forwarded-For: 1.2.3.4, <real_ip>`), allowing them to completely bypass rate limiting logic. 
🎯 **Impact:** Attackers could exhaust server resources via DoS/brute-force attacks because they are incorrectly identified as different clients.
🔧 **Fix:** Implemented a new, shared `get_client_ip` function for `slowapi`'s `Limiter` that securely parses the rightmost IP appended by a trusted proxy, and explicitly checks if the `TRUST_REVERSE_PROXY` environment variable is enabled. Refactored `IPWhitelistMiddleware` to reuse this safe logic to maintain DRY compliance.
✅ **Verification:** Verified that `get_client_ip` enforces `TRUST_REVERSE_PROXY` and that unit/e2e tests (`poetry run pytest`) pass successfully. Evaluated the implementation logic manually by reading code structure.

---
*PR created automatically by Jules for task [11287842168150850580](https://jules.google.com/task/11287842168150850580) started by @brewmarsh*