### PR TITLE
⚡ Bolt: [performance improvement] Layer disk cache beneath TTL cache in `get_mappings_data`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 ## 2024-07-12 - Redundant Backend Polling in SSE Handlers
 **Learning:** In frontend applications listening to Server-Sent Events (SSE), it is a performance anti-pattern to trigger separate HTTP polling requests (e.g., `fetch()`) to check for a specific state or error if the data required to determine that state is already included in the SSE payload itself.
 **Action:** Always verify if the necessary data is already available in the SSE message stream (e.g., checking `data.log.includes(...)`) to eliminate redundant HTTP requests, reduce server load, and lower memory footprint by removing unnecessary API endpoints.
+
+## 2025-10-27 - Prevent heavy disk I/O on every request
+**Learning:** When reading from a background-synced JSON file (like `cache.json`) to prevent N+1 live API calls, directly parsing the file on every API request or SSE tick incurs heavy disk I/O and JSON deserialization overhead, becoming a new bottleneck.
+**Action:** Layer the disk cache read beneath an in-memory TTL cache (e.g., `_mappings_cache`), and wrap the disk read in a `try...except (FileNotFoundError, json.JSONDecodeError)` block to provide a safe fallback in case the background daemon is currently writing to the file or hasn't created it yet.

--- a/app/app.py
+++ b/app/app.py
@@ -257,6 +257,29 @@ def get_mappings_data():
     if _mappings_cache is not None and time.time() < _mappings_cache_time + 60:
         return _mappings_cache
 
+    # ⚡ Bolt Optimization: Layer the background-synced disk cache beneath the in-memory TTL cache.
+    # Impact: Prevents heavy disk I/O on every request and avoids live API calls that block the event loop.
+    try:
+        with Path("/app/cache.json").open() as f:
+            cache_data = json.load(f)
+            if not isinstance(cache_data, dict):
+                raise ValueError("Cache data is not a dictionary")
+            # Reconstruct the mapped list since cache.json only stores the count
+            pihole_records = cache_data.get("pihole", {})
+            meraki_clients = cache_data.get("meraki", [])
+            mapped_devices, unmapped_meraki_devices = _map_devices(meraki_clients, pihole_records)
+            result = {
+                "pihole": pihole_records,
+                "meraki": meraki_clients,
+                "mapped": mapped_devices,
+                "unmapped_meraki": unmapped_meraki_devices
+            }
+            _mappings_cache = result
+            _mappings_cache_time = time.time()
+            return result
+    except (FileNotFoundError, json.JSONDecodeError, ValueError):
+        log.warning("Cache file not found or corrupted, falling back to live API calls.")
+
     try:
         config = load_app_config_from_env()
         pihole_url = os.getenv("PIHOLE_API_URL")


### PR DESCRIPTION
💡 **What:** Modified `get_mappings_data` in `app/app.py` to use the background-synced `/app/cache.json` disk cache as a fallback layer beneath the primary in-memory TTL cache. It safely validates the cache and reconstructs the mapped devices list locally, falling back to live API calls only if the file is missing or corrupted.

🎯 **Why:** To prevent heavy disk I/O and JSON deserialization overhead on every API request or SSE tick, which became a new bottleneck. This tiered strategy avoids both the N+1 live API call problem and the constant file reads.

📊 **Impact:** Significantly reduces CPU usage and latency per API call/SSE tick. Disk reads now occur at most once every 60 seconds (when the in-memory TTL expires), instead of continuously blocking the async event loop.

🔬 **Measurement:** Compare CPU and memory usage, as well as API request latency logs, during an active SSE connection with many concurrent clients.

---
*PR created automatically by Jules for task [7400141316566475668](https://jules.google.com/task/7400141316566475668) started by @brewmarsh*