### PR TITLE
🎨 Palette: Add accessibility and close handlers to welcome screen

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -36,3 +36,7 @@
 ## 2024-07-12 - Accessible Visual Indicators for Required Form Fields
 **Learning:** When using standard `required` HTML attributes on form fields, users—and especially screen reader users—need clear indication *before* submission that the field is mandatory. A red asterisk is a common visual convention, but screen readers may mispronounce or ignore it if not tagged correctly.
 **Action:** Always wrap visual indicators like asterisks with `aria-hidden="true"` and supplement them with explicit `<span class="visually-hidden"> (required)</span>` text within the `<label>` to ensure both sighted and screen-reader users understand the requirement.
+
+## 2026-07-28 - Custom Modal Overlay Close Mechanisms and Accessibility
+**Learning:** When building custom modal overlays without native `<dialog>` or framework components (like Bootstrap `.modal`), always implement explicit event listeners for the `Escape` key and background (backdrop) clicks, and include standard ARIA attributes (`role="dialog"`, `aria-modal="true"`, and `aria-labelledby`) to ensure proper accessibility and screen reader support. Additionally, ensure event listeners correctly account for conditional rendering (like Jinja `{% if %}` blocks) to prevent `TypeError` exceptions on elements that might not exist in the DOM.
+**Action:** Always add standard ARIA attributes and robust close handlers (Escape, click outside) for custom modal implementations, ensuring these scripts check for element existence if the HTML is conditionally rendered.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,10 +12,10 @@
 </head>
 <body>
     {% if show_welcome_banner %}
-    <div id="welcome-screen">
+    <div id="welcome-screen" role="dialog" aria-modal="true" aria-labelledby="welcome-title">
         <div class="card">
             <div class="card-body">
-                <h5 class="card-title">Welcome to Meraki Pi-hole Sync!</h5>
+                <h5 id="welcome-title" class="card-title">Welcome to Meraki Pi-hole Sync!</h5>
                 <p class="card-text">
                     This application synchronizes client information from the Meraki API to a Pi-hole instance.
                     It identifies Meraki clients with Fixed IP Assignments (DHCP Reservations) and
@@ -452,15 +452,30 @@
             }
             document.getElementById('loading-screen').style.display = 'none';
 
-            if (!localStorage.getItem('welcomeScreenSeen')) {
-                document.getElementById('welcome-screen').style.display = 'flex';
-                document.getElementById('close-welcome-screen').focus();
-            }
+            const welcomeScreen = document.getElementById('welcome-screen');
+            if (welcomeScreen) {
+                if (!localStorage.getItem('welcomeScreenSeen')) {
+                    welcomeScreen.style.display = 'flex';
+                    document.getElementById('close-welcome-screen').focus();
+                }
 
-            document.getElementById('close-welcome-screen').addEventListener('click', () => {
-                document.getElementById('welcome-screen').style.display = 'none';
-                localStorage.setItem('welcomeScreenSeen', 'true');
-            });
+                const closeWelcomeScreen = () => {
+                    welcomeScreen.style.display = 'none';
+                    localStorage.setItem('welcomeScreenSeen', 'true');
+                };
+
+                document.getElementById('close-welcome-screen').addEventListener('click', closeWelcomeScreen);
+
+                welcomeScreen.addEventListener('click', (e) => {
+                    if (e.target === welcomeScreen) closeWelcomeScreen();
+                });
+
+                document.addEventListener('keydown', (e) => {
+                    if (e.key === 'Escape' && welcomeScreen.style.display === 'flex') {
+                        closeWelcomeScreen();
+                    }
+                });
+            }
 
             fetch('/cache')
                 .then(response => response.json())


### PR DESCRIPTION
### 💡 What
Added ARIA accessibility attributes to the custom `#welcome-screen` modal overlay and implemented standard close mechanisms (the `Escape` key and clicking the backdrop/background outside the modal).

### 🎯 Why
Custom modals implemented without native `<dialog>` tags require explicit instructions for screen readers (`role="dialog"` and `aria-modal="true"`) to understand the context. Keyboard users also expect the standard convention of pressing `Escape` to close overlays, and mouse users expect to be able to click away to dismiss it. Furthermore, a safety check was added to ensure the DOM elements actually exist before attaching listeners, preventing `TypeError` exceptions if the Jinja conditional doesn't render the modal.

### 📸 Before/After
No visual style changes; the enhancement is purely behavioral and accessibility-focused for keyboard, mouse, and screen-reader users.

### ♿ Accessibility
- Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby="welcome-title"` to explicitly declare the modal container to screen readers.
- Bound a `keydown` listener for the `Escape` key.
- Bound a `click` listener for the backdrop (closing only when the overlay itself is clicked, not its children).

---
*PR created automatically by Jules for task [413617373839734038](https://jules.google.com/task/413617373839734038) started by @brewmarsh*