### PR TITLE
🎨 Palette: Add keyboard scrolling support for log boxes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -40,3 +40,7 @@
 ## 2026-07-28 - Custom Modal Overlay Close Mechanisms and Accessibility
 **Learning:** When building custom modal overlays without native `<dialog>` or framework components (like Bootstrap `.modal`), always implement explicit event listeners for the `Escape` key and background (backdrop) clicks, and include standard ARIA attributes (`role="dialog"`, `aria-modal="true"`, and `aria-labelledby`) to ensure proper accessibility and screen reader support. Additionally, ensure event listeners correctly account for conditional rendering (like Jinja `{% if %}` blocks) to prevent `TypeError` exceptions on elements that might not exist in the DOM.
 **Action:** Always add standard ARIA attributes and robust close handlers (Escape, click outside) for custom modal implementations, ensuring these scripts check for element existence if the HTML is conditionally rendered.
+
+## 2024-07-28 - Keyboard accessibility for scrollable regions
+**Learning:** Elements like `<pre>` or `<div>` with `overflow: scroll` or `overflow: auto` (like `.log-box` in this app) are completely inaccessible to keyboard users by default. Since they don't receive focus natively, keyboard-only users cannot scroll through their content.
+**Action:** Always add `tabindex="0"` to visually scrollable regions so they can be focused and scrolled via keyboard arrow keys, and ensure they have a visible `:focus-visible` outline for sighted keyboard users.

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -112,3 +112,8 @@
     justify-content: center;
     align-items: center;
 }
+
+.log-box:focus-visible {
+    outline: 2px solid #0d6efd;
+    outline-offset: -2px;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -80,7 +80,7 @@
                     </div>
                     <div id="pihole-body" class="collapse">
                         <div class="card-body">
-                            <pre id="pihole-mappings" class="log-box"></pre>
+                            <pre tabindex="0" id="pihole-mappings" class="log-box"></pre>
                         </div>
                     </div>
                 </div>
@@ -92,7 +92,7 @@
                     </div>
                     <div id="meraki-body" class="collapse">
                         <div class="card-body">
-                            <pre id="meraki-mappings" class="log-box"></pre>
+                            <pre tabindex="0" id="meraki-mappings" class="log-box"></pre>
                         </div>
                     </div>
                 </div>
@@ -104,7 +104,7 @@
                     </div>
                     <div id="mapped-body" class="collapse">
                         <div class="card-body">
-                            <pre id="mapped-devices" class="log-box"></pre>
+                            <pre tabindex="0" id="mapped-devices" class="log-box"></pre>
                         </div>
                     </div>
                 </div>
@@ -116,7 +116,7 @@
                     </div>
                     <div id="unmapped-meraki-body" class="collapse">
                         <div class="card-body">
-                            <pre id="unmapped-meraki-devices" class="log-box"></pre>
+                            <pre tabindex="0" id="unmapped-meraki-devices" class="log-box"></pre>
                         </div>
                     </div>
                 </div>
@@ -128,7 +128,7 @@
                     </div>
                     <div id="logs-body" class="collapse">
                         <div class="card-body">
-                            <pre id="sync-log" class="log-box"></pre>
+                            <pre tabindex="0" id="sync-log" class="log-box"></pre>
                             <button class="btn btn-sm btn-outline-secondary" data-log="sync" data-action="copy" aria-label="Copy sync logs to clipboard" title="Copy sync logs to clipboard">Copy</button>
                             <button class="btn btn-sm btn-outline-danger" data-log="sync" data-action="clear" aria-label="Clear sync logs" title="Clear sync logs">Clear</button>
                         </div>
@@ -141,7 +141,7 @@
                     </div>
                     <div id="changelog-body" class="collapse">
                         <div class="card-body">
-                            <pre id="changelog" class="log-box"></pre>
+                            <pre tabindex="0" id="changelog" class="log-box"></pre>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
💡 What: Added `tabindex="0"` to all scrollable log boxes (`<pre>` tags in `index.html`) and implemented a `:focus-visible` styling rule in `style.css`.
🎯 Why: Elements with `overflow: scroll` or `auto` cannot be scrolled via the keyboard unless they can receive focus. Sighted keyboard users also need a distinct visual cue when an element receives focus.
📸 Before/After: Sighted users can now see a clear blue outline (`2px solid #0d6efd`) when focusing on a log box.
♿ Accessibility: Keyboard-only users can now natively focus and scroll through long log histories using arrow keys. Checked for regressions using unit tests. Documented learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [2914960888068023864](https://jules.google.com/task/2914960888068023864) started by @brewmarsh*