### PR TITLE
🎨 Palette: Make scrollable log boxes keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -40,3 +40,7 @@
 ## 2026-07-28 - Custom Modal Overlay Close Mechanisms and Accessibility
 **Learning:** When building custom modal overlays without native `<dialog>` or framework components (like Bootstrap `.modal`), always implement explicit event listeners for the `Escape` key and background (backdrop) clicks, and include standard ARIA attributes (`role="dialog"`, `aria-modal="true"`, and `aria-labelledby`) to ensure proper accessibility and screen reader support. Additionally, ensure event listeners correctly account for conditional rendering (like Jinja `{% if %}` blocks) to prevent `TypeError` exceptions on elements that might not exist in the DOM.
 **Action:** Always add standard ARIA attributes and robust close handlers (Escape, click outside) for custom modal implementations, ensuring these scripts check for element existence if the HTML is conditionally rendered.
+
+## 2024-11-20 - Keyboard Accessibility for Scrollable Regions
+**Learning:** Visually scrollable regions like `<pre>` blocks configured with `overflow: scroll` or `auto` are not focusable by default, meaning keyboard-only users cannot scroll through their content using arrow keys.
+**Action:** Always add `tabindex="0"` to visually scrollable regions so they can receive keyboard focus and be scrolled. Additionally, ensure there is a clear visual indicator for sighted keyboard users by adding a `:focus-visible` outline.

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -112,3 +112,8 @@
     justify-content: center;
     align-items: center;
 }
+
+.log-box:focus-visible {
+    outline: 2px solid #0d6efd;
+    outline-offset: -2px;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -80,7 +80,7 @@
                     </div>
                     <div id="pihole-body" class="collapse">
                         <div class="card-body">
-                            <pre id="pihole-mappings" class="log-box"></pre>
+                            <pre id="pihole-mappings" class="log-box" tabindex="0"></pre>
                         </div>
                     </div>
                 </div>
@@ -92,7 +92,7 @@
                     </div>
                     <div id="meraki-body" class="collapse">
                         <div class="card-body">
-                            <pre id="meraki-mappings" class="log-box"></pre>
+                            <pre id="meraki-mappings" class="log-box" tabindex="0"></pre>
                         </div>
                     </div>
                 </div>
@@ -104,7 +104,7 @@
                     </div>
                     <div id="mapped-body" class="collapse">
                         <div class="card-body">
-                            <pre id="mapped-devices" class="log-box"></pre>
+                            <pre id="mapped-devices" class="log-box" tabindex="0"></pre>
                         </div>
                     </div>
                 </div>
@@ -116,7 +116,7 @@
                     </div>
                     <div id="unmapped-meraki-body" class="collapse">
                         <div class="card-body">
-                            <pre id="unmapped-meraki-devices" class="log-box"></pre>
+                            <pre id="unmapped-meraki-devices" class="log-box" tabindex="0"></pre>
                         </div>
                     </div>
                 </div>
@@ -128,7 +128,7 @@
                     </div>
                     <div id="logs-body" class="collapse">
                         <div class="card-body">
-                            <pre id="sync-log" class="log-box"></pre>
+                            <pre id="sync-log" class="log-box" tabindex="0"></pre>
                             <button class="btn btn-sm btn-outline-secondary" data-log="sync" data-action="copy" aria-label="Copy sync logs to clipboard" title="Copy sync logs to clipboard">Copy</button>
                             <button class="btn btn-sm btn-outline-danger" data-log="sync" data-action="clear" aria-label="Clear sync logs" title="Clear sync logs">Clear</button>
                         </div>
@@ -141,7 +141,7 @@
                     </div>
                     <div id="changelog-body" class="collapse">
                         <div class="card-body">
-                            <pre id="changelog" class="log-box"></pre>
+                            <pre id="changelog" class="log-box" tabindex="0"></pre>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
💡 What:
Added `tabindex="0"` to all `<pre class="log-box">` elements in the application and introduced a `:focus-visible` CSS rule for them.

🎯 Why:
Visually scrollable regions (like `<pre>` blocks configured with `overflow: scroll` or `auto`) are not focusable by default. This meant that keyboard-only users were entirely unable to scroll through the log contents, effectively hiding important information from them. By adding `tabindex="0"`, these regions can now receive focus and be scrolled using arrow keys. The `:focus-visible` outline ensures sighted keyboard users know when the box is focused.

📸 Before/After:
Before: Log boxes could not be focused with the Tab key.
After: Log boxes can be focused with the Tab key and display a clear blue outline.

♿ Accessibility:
Fixes a critical keyboard trap/inaccessibility issue where content was unavailable to non-mouse users. Also provides clear visual affordance of focus state.

---
*PR created automatically by Jules for task [10002068685206427424](https://jules.google.com/task/10002068685206427424) started by @brewmarsh*