### PR TITLE
🎨 Palette: [UX improvement] Add keyboard focus and visible outline to log boxes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -40,3 +40,7 @@
 ## 2026-07-28 - Custom Modal Overlay Close Mechanisms and Accessibility
 **Learning:** When building custom modal overlays without native `<dialog>` or framework components (like Bootstrap `.modal`), always implement explicit event listeners for the `Escape` key and background (backdrop) clicks, and include standard ARIA attributes (`role="dialog"`, `aria-modal="true"`, and `aria-labelledby`) to ensure proper accessibility and screen reader support. Additionally, ensure event listeners correctly account for conditional rendering (like Jinja `{% if %}` blocks) to prevent `TypeError` exceptions on elements that might not exist in the DOM.
 **Action:** Always add standard ARIA attributes and robust close handlers (Escape, click outside) for custom modal implementations, ensuring these scripts check for element existence if the HTML is conditionally rendered.
+
+## 2026-08-01 - Keyboard accessibility for scrollable log regions
+**Learning:** By default, scrollable regions (`overflow: scroll` or `auto`) like `<pre>` blocks for logs cannot be scrolled using the keyboard unless they can receive focus. This creates an accessibility barrier for keyboard-only users who need to read long log output.
+**Action:** Always add `tabindex="0"` to visually scrollable custom components or regions to allow keyboard focus, and pair it with a visible `:focus-visible` outline for sighted keyboard users.

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -112,3 +112,8 @@
     justify-content: center;
     align-items: center;
 }
+
+.log-box:focus-visible {
+    outline: 2px solid #0d6efd;
+    outline-offset: -2px;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -80,7 +80,7 @@
                     </div>
                     <div id="pihole-body" class="collapse">
                         <div class="card-body">
-                            <pre id="pihole-mappings" class="log-box"></pre>
+                            <pre id="pihole-mappings" class="log-box" tabindex="0"></pre>
                         </div>
                     </div>
                 </div>
@@ -92,7 +92,7 @@
                     </div>
                     <div id="meraki-body" class="collapse">
                         <div class="card-body">
-                            <pre id="meraki-mappings" class="log-box"></pre>
+                            <pre id="meraki-mappings" class="log-box" tabindex="0"></pre>
                         </div>
                     </div>
                 </div>
@@ -104,7 +104,7 @@
                     </div>
                     <div id="mapped-body" class="collapse">
                         <div class="card-body">
-                            <pre id="mapped-devices" class="log-box"></pre>
+                            <pre id="mapped-devices" class="log-box" tabindex="0"></pre>
                         </div>
                     </div>
                 </div>
@@ -116,7 +116,7 @@
                     </div>
                     <div id="unmapped-meraki-body" class="collapse">
                         <div class="card-body">
-                            <pre id="unmapped-meraki-devices" class="log-box"></pre>
+                            <pre id="unmapped-meraki-devices" class="log-box" tabindex="0"></pre>
                         </div>
                     </div>
                 </div>
@@ -128,7 +128,7 @@
                     </div>
                     <div id="logs-body" class="collapse">
                         <div class="card-body">
-                            <pre id="sync-log" class="log-box"></pre>
+                            <pre id="sync-log" class="log-box" tabindex="0"></pre>
                             <button class="btn btn-sm btn-outline-secondary" data-log="sync" data-action="copy" aria-label="Copy sync logs to clipboard" title="Copy sync logs to clipboard">Copy</button>
                             <button class="btn btn-sm btn-outline-danger" data-log="sync" data-action="clear" aria-label="Clear sync logs" title="Clear sync logs">Clear</button>
                         </div>
@@ -141,7 +141,7 @@
                     </div>
                     <div id="changelog-body" class="collapse">
                         <div class="card-body">
-                            <pre id="changelog" class="log-box"></pre>
+                            <pre id="changelog" class="log-box" tabindex="0"></pre>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
💡 What: Added `tabindex="0"` to all `<pre class="log-box">` elements and introduced a `.log-box:focus-visible` CSS rule.
🎯 Why: Scrollable regions (like `<pre>` log blocks) cannot be scrolled by keyboard-only users unless they can receive focus. This improvement allows keyboard-only users to focus on the log boxes and scroll through them using the arrow keys. The `:focus-visible` outline ensures sighted keyboard users receive clear visual feedback while preventing an unsightly outline for mouse users clicking the log box.
📸 Before/After: See generated Playwright video/screenshots showing the blue focus outline navigating through the log sections.
♿ Accessibility: Ensures keyboard accessibility and proper focus states for visually scrollable regions, adhering to WCAG guidelines for keyboard navigation.

---
*PR created automatically by Jules for task [12387761060561629763](https://jules.google.com/task/12387761060561629763) started by @brewmarsh*