### PR TITLE
⚡ Bolt: Optimize get_sync_interval to prevent redundant config parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 ## 2025-10-27 - Prevent heavy disk I/O on every request
 **Learning:** When reading from a background-synced JSON file (like `cache.json`) to prevent N+1 live API calls, directly parsing the file on every API request or SSE tick incurs heavy disk I/O and JSON deserialization overhead, becoming a new bottleneck.
 **Action:** Layer the disk cache read beneath an in-memory TTL cache (e.g., `_mappings_cache`), and wrap the disk read in a `try...except (FileNotFoundError, json.JSONDecodeError)` block to provide a safe fallback in case the background daemon is currently writing to the file or hasn't created it yet.
+
+## 2026-07-25 - Prevent redundant config parsing and logging inside loops
+**Learning:** Found an issue where `load_app_config_from_env()` was repeatedly called in `get_sync_interval()`, which itself is called on every tick of the SSE `while True` stream. This caused unnecessary CPU overhead and polluted the logs with "Successfully loaded configuration" messages repeatedly.
+**Action:** When working with configuration loading functions that read from environment variables and perform validation, use caching mechanisms like `@lru_cache(maxsize=1)` to ensure the parsing and logging only happen once per application lifecycle, preventing heavy overhead and log spam in high-frequency loops.

--- a/app/sync_logic.py
+++ b/app/sync_logic.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 from datetime import datetime
+from functools import lru_cache
 from pathlib import Path
 
 import meraki
@@ -26,6 +27,7 @@ ENV_CHANGELOG_FILE_PATH = "CHANGELOG_FILE_PATH"
 ENV_SYNC_INTERVAL_FILE_PATH = "SYNC_INTERVAL_FILE_PATH"
 
 
+@lru_cache(maxsize=1)
 def load_app_config_from_env():
     """
     Loads all application configuration from environment variables.


### PR DESCRIPTION
💡 What: Applied `@functools.lru_cache(maxsize=1)` to the `load_app_config_from_env()` function.
🎯 Why: `load_app_config_from_env()` was being called by `get_sync_interval()` on every tick of the SSE `while True` loop per client connection. This caused unnecessary CPU overhead to parse the full app config and generated redundant "Successfully loaded configuration" logs.
📊 Impact: Eliminates O(N) configuration parsing and logging overhead in the SSE stream loop, caching it to O(1) per application lifecycle. Reduces memory and CPU footprint.
🔬 Measurement: Verify by starting the application and viewing the application logs when an SSE connection is active; the configuration loaded log will only appear once instead of repeatedly.

---
*PR created automatically by Jules for task [11447269215859158240](https://jules.google.com/task/11447269215859158240) started by @brewmarsh*