### PR TITLE
🎨 Palette: Add keyboard accessibility (tabindex & focus) to scrollable log boxes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -40,3 +40,7 @@
 ## 2026-07-28 - Custom Modal Overlay Close Mechanisms and Accessibility
 **Learning:** When building custom modal overlays without native `<dialog>` or framework components (like Bootstrap `.modal`), always implement explicit event listeners for the `Escape` key and background (backdrop) clicks, and include standard ARIA attributes (`role="dialog"`, `aria-modal="true"`, and `aria-labelledby`) to ensure proper accessibility and screen reader support. Additionally, ensure event listeners correctly account for conditional rendering (like Jinja `{% if %}` blocks) to prevent `TypeError` exceptions on elements that might not exist in the DOM.
 **Action:** Always add standard ARIA attributes and robust close handlers (Escape, click outside) for custom modal implementations, ensuring these scripts check for element existence if the HTML is conditionally rendered.
+
+## 2026-07-26 - Accessible Scrollable Regions
+**Learning:** Elements with scrollable overflow (like `<pre class="log-box">`) are not natively focusable by default, meaning keyboard-only users cannot scroll their content using arrow keys.
+**Action:** Always add `tabindex="0"` to visually scrollable regions and include a visible `:focus-visible` outline for sighted keyboard users to ensure they are fully accessible and usable.

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -112,3 +112,8 @@
     justify-content: center;
     align-items: center;
 }
+
+.log-box:focus-visible {
+    outline: 2px solid #0d6efd;
+    outline-offset: -2px;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -80,7 +80,7 @@
                     </div>
                     <div id="pihole-body" class="collapse">
                         <div class="card-body">
-                            <pre id="pihole-mappings" class="log-box"></pre>
+                            <pre id="pihole-mappings" class="log-box" tabindex="0"></pre>
                         </div>
                     </div>
                 </div>
@@ -92,7 +92,7 @@
                     </div>
                     <div id="meraki-body" class="collapse">
                         <div class="card-body">
-                            <pre id="meraki-mappings" class="log-box"></pre>
+                            <pre id="meraki-mappings" class="log-box" tabindex="0"></pre>
                         </div>
                     </div>
                 </div>
@@ -104,7 +104,7 @@
                     </div>
                     <div id="mapped-body" class="collapse">
                         <div class="card-body">
-                            <pre id="mapped-devices" class="log-box"></pre>
+                            <pre id="mapped-devices" class="log-box" tabindex="0"></pre>
                         </div>
                     </div>
                 </div>
@@ -116,7 +116,7 @@
                     </div>
                     <div id="unmapped-meraki-body" class="collapse">
                         <div class="card-body">
-                            <pre id="unmapped-meraki-devices" class="log-box"></pre>
+                            <pre id="unmapped-meraki-devices" class="log-box" tabindex="0"></pre>
                         </div>
                     </div>
                 </div>
@@ -128,7 +128,7 @@
                     </div>
                     <div id="logs-body" class="collapse">
                         <div class="card-body">
-                            <pre id="sync-log" class="log-box"></pre>
+                            <pre id="sync-log" class="log-box" tabindex="0"></pre>
                             <button class="btn btn-sm btn-outline-secondary" data-log="sync" data-action="copy" aria-label="Copy sync logs to clipboard" title="Copy sync logs to clipboard">Copy</button>
                             <button class="btn btn-sm btn-outline-danger" data-log="sync" data-action="clear" aria-label="Clear sync logs" title="Clear sync logs">Clear</button>
                         </div>
@@ -141,7 +141,7 @@
                     </div>
                     <div id="changelog-body" class="collapse">
                         <div class="card-body">
-                            <pre id="changelog" class="log-box"></pre>
+                            <pre id="changelog" class="log-box" tabindex="0"></pre>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
💡 **What:** Added `tabindex="0"` to all `<pre class="log-box">` elements in `app/templates/index.html` and a `.log-box:focus-visible` outline in `app/static/style.css`.
🎯 **Why:** To allow keyboard-only users to focus on visually scrollable log regions and use arrow keys to scroll through the content, which wasn't possible previously because `<pre>` elements are not focusable by default.
📸 **Before/After:** Not applicable/visible without keyboard interaction, but the focus ring matches the standard Bootstrap blue (`#0d6efd`) for consistency.
♿ **Accessibility:** Fixes a critical keyboard trapping/accessibility issue where screen reader and keyboard-only users could not interact with or scroll the log text boxes.

---
*PR created automatically by Jules for task [11129316463116118159](https://jules.google.com/task/11129316463116118159) started by @brewmarsh*