### PR TITLE
⚡ Bolt: Filter Meraki networks before executing concurrent API requests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,7 @@
 ## 2025-10-28 - Caching Configuration Parsing
 **Learning:** Functions that parse environment variables and construct configuration objects can introduce redundant overhead when called repeatedly in hot loops (like SSE streams). Bypassing them with direct `os.getenv()` calls is an anti-pattern as it breaks centralized configuration and mocked tests.
 **Action:** Use `@functools.lru_cache(maxsize=1)` on the central configuration loading function (e.g., `load_app_config_from_env`) to safely cache the parsed results and eliminate redundant processing overhead without fracturing configuration management.
+
+## 2025-10-30 - Missing filtering before fanning out HTTP requests
+**Learning:** Found an N+1 API call problem in `get_all_relevant_meraki_clients` where all devices across the entire organization were passed directly into a `ThreadPoolExecutor` to fetch fixed IP assignments. Even though a list of relevant `network_ids` was provided in the configuration, the script failed to filter the devices beforehand, causing numerous expensive and unnecessary external API requests to unrelated devices.
+**Action:** Always filter data collections (e.g. by `networkId` or similar criteria) *before* fanning them out to concurrent processing loops or executors. Adding a simple list comprehension to filter the devices reduced the amount of work submitted to the thread pool and minimized unnecessary API calls.

--- a/app/clients/meraki_client.py
+++ b/app/clients/meraki_client.py
@@ -82,6 +82,11 @@ def get_all_relevant_meraki_clients(dashboard: meraki.DashboardAPI, config: dict
         log.error("Meraki API error while fetching organization devices", error=e, org_id=org_id)
         return []
 
+    # ⚡ Bolt Optimization: Filter devices by network ID if specified
+    # Impact: Dramatically reduces unnecessary API calls (and ThreadPool processing) for organizations with many networks.
+    if config.get("meraki_network_ids"):
+        devices = [d for d in devices if d.get("networkId") in config["meraki_network_ids"]]
+
     def fetch_for_device(device):
         if device['model'].startswith('MS'):
             return _get_fixed_ip_assignments_from_switch(dashboard, device)


### PR DESCRIPTION
💡 What:
Filtered the list of all Meraki devices by the specified `meraki_network_ids` before passing them to the `ThreadPoolExecutor`.

🎯 Why:
The application was making an N+1 API call mistake by creating a worker for *every single device in the organization* to fetch its fixed IP assignments, even if the user only configured a subset of networks in `meraki_network_ids`.

📊 Impact:
Significantly reduces the number of unnecessary API requests made to the Meraki Dashboard by skipping devices in unrelated networks, lowering latency and API rate-limiting risk.

🔬 Measurement:
Observe fewer HTTP requests in logs when `MERAKI_NETWORK_IDS` is set, and a faster completion time for syncing.

---
*PR created automatically by Jules for task [6738349963214801523](https://jules.google.com/task/6738349963214801523) started by @brewmarsh*