### PR TITLE
🎨 Palette: Add skip-to-content link and document language attributes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,7 @@
 ## 2026-07-26 - Accessible Scrollable Regions
 **Learning:** Elements with scrollable overflow (like `<pre class="log-box">`) are not natively focusable by default, meaning keyboard-only users cannot scroll their content using arrow keys.
 **Action:** Always add `tabindex="0"` to visually scrollable regions and include a visible `:focus-visible` outline for sighted keyboard users to ensure they are fully accessible and usable.
+
+## 2024-07-29 - Accessibility for Document Language and Skip Links
+**Learning:** Screen readers rely on the `lang` attribute on the `<html>` tag to correctly pronounce text. Omitting it leads to poor user experiences. Additionally, for applications with top navigation, a visually hidden "Skip to main content" link that becomes visible on focus provides an essential shortcut for keyboard users, preventing them from having to tab through every navigation item repeatedly.
+**Action:** Always add the `lang` attribute (e.g., `lang="en"`) to the root HTML element, and implement a "Skip to main content" link at the top of the body that targets the main `<main>` container for keyboard and screen reader accessibility.

--- a/app/templates/404.html
+++ b/app/templates/404.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Page Not Found</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
 </head>

--- a/app/templates/500.html
+++ b/app/templates/500.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Internal Server Error</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
 </head>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Meraki Pi-hole Sync</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="/static/style.css">
@@ -11,6 +13,7 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="visually-hidden-focusable position-absolute top-0 start-0 m-3 p-2 bg-primary text-white rounded shadow" style="z-index: 1050;">Skip to main content</a>
     {% if show_welcome_banner %}
     <div id="welcome-screen" role="dialog" aria-modal="true" aria-labelledby="welcome-title">
         <div class="card">
@@ -47,7 +50,7 @@
         </div>
     </nav>
 
-    <div class="container">
+    <main id="main-content" class="container" tabindex="-1" style="outline: none;">
         <div class="row mt-4">
             <div class="col-md-8">
                 <div class="card mt-4" id="charts-card">
@@ -172,7 +175,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    </main>
 
     <div class="toast-container position-fixed bottom-0 end-0 p-3">
       <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">


### PR DESCRIPTION
💡 What: Added `lang="en"` and standard `<meta>` tags to `<html>` and `<head>` tags in all templates. Added a hidden "Skip to main content" link that becomes visible on keyboard focus and targets a valid `<main>` container.
🎯 Why: Essential accessibility for screen readers and keyboard users.
📸 Before/After: Visual UI unchanged for mouse users. Focusable skip link added for keyboard users.
♿ Accessibility:
 - `lang` attribute ensures screen readers use the correct pronunciation rules.
 - Viewport meta tag ensures text scales properly on mobile.
 - Skip link allows keyboard users to bypass top navigation.

---
*PR created automatically by Jules for task [9443481258349495242](https://jules.google.com/task/9443481258349495242) started by @brewmarsh*