### PR TITLE
🎨 Palette: Add Skip to Main Content Link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,7 @@
 ## 2026-07-26 - Accessible Scrollable Regions
 **Learning:** Elements with scrollable overflow (like `<pre class="log-box">`) are not natively focusable by default, meaning keyboard-only users cannot scroll their content using arrow keys.
 **Action:** Always add `tabindex="0"` to visually scrollable regions and include a visible `:focus-visible` outline for sighted keyboard users to ensure they are fully accessible and usable.
+
+## 2026-07-28 - Skip to main content accessibility link
+**Learning:** Adding a visually hidden, focusable "Skip to main content" link as the first focusable element helps keyboard and screen reader users bypass repetitive header and navigation links. Furthermore, mapping the target container using a standard HTML5 `<main>` tag with appropriate ARIA attributes (such as `id` matching the link, `tabindex="-1"`, and `style="outline: none;"`) ensures focus correctly applies when activated, creating a smoother reading flow without unnecessary visual outlines.
+**Action:** Always implement a "Skip to main content" link for application structures with persistent navbars and utilize the `<main>` tag for structural semantics to ensure clear keyboard navigation paths.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,6 +11,7 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
     {% if show_welcome_banner %}
     <div id="welcome-screen" role="dialog" aria-modal="true" aria-labelledby="welcome-title">
         <div class="card">
@@ -47,7 +48,7 @@
         </div>
     </nav>
 
-    <div class="container">
+    <main id="main-content" class="container" tabindex="-1" style="outline: none;">
         <div class="row mt-4">
             <div class="col-md-8">
                 <div class="card mt-4" id="charts-card">
@@ -183,7 +184,7 @@
         <div class="toast-body">
         </div>
       </div>
-    </div>
+    </main>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>


### PR DESCRIPTION
💡 What: Added a "Skip to main content" link for keyboard accessibility and updated the main application layout wrapper from a `div` to a `<main>` tag.
🎯 Why: "Skip to main content" links are crucial for keyboard and screen reader users to bypass repetitive header navigation and jump straight into the application's primary content without excessive tabbing.
📸 Before/After: Visual presentation is unmodified for standard mouse users; the link visually appears only when focused.
♿ Accessibility:
- Added a `<a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>` element immediately after the `<body>` tag.
- Replaced the primary container `<div class="container">` with a `<main id="main-content" class="container" tabindex="-1" style="outline: none;">` to ensure it is properly linked and focused without displaying a distracting focus ring when targeted.
- Recorded UX learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [12390653843493530813](https://jules.google.com/task/12390653843493530813) started by @brewmarsh*