### PR TITLE
⚡ Bolt: Filter devices by network ID to avoid unnecessary API calls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,6 @@
 ## 2025-10-28 - Caching Configuration Parsing
 **Learning:** Functions that parse environment variables and construct configuration objects can introduce redundant overhead when called repeatedly in hot loops (like SSE streams). Bypassing them with direct `os.getenv()` calls is an anti-pattern as it breaks centralized configuration and mocked tests.
 **Action:** Use `@functools.lru_cache(maxsize=1)` on the central configuration loading function (e.g., `load_app_config_from_env`) to safely cache the parsed results and eliminate redundant processing overhead without fracturing configuration management.
+## 2025-10-31 - Filter devices by network ID before fanning out in concurrent executors
+**Learning:** Found an N+1 query problem where a list of Meraki devices is fetched and passed to a `ThreadPoolExecutor` without filtering out devices that do not belong to the selected network IDs. This resulted in redundant API calls for devices in unselected networks, which wasted bandwidth and increased latency.
+**Action:** Always filter data collections (e.g., filtering devices by network ID) before fanning them out to a worker pool to avoid unnecessary external HTTP requests and prevent N+1 API call problems.

--- a/app/clients/meraki_client.py
+++ b/app/clients/meraki_client.py
@@ -82,6 +82,12 @@ def get_all_relevant_meraki_clients(dashboard: meraki.DashboardAPI, config: dict
         log.error("Meraki API error while fetching organization devices", error=e, org_id=org_id)
         return []
 
+    # ⚡ Bolt Optimization: Filter devices by network ID before passing to executor
+    # Impact: Prevents N+1 API calls to fetch data from devices in unselected networks.
+    meraki_network_ids = config.get("meraki_network_ids")
+    if meraki_network_ids:
+        devices = [d for d in devices if d.get("networkId") in meraki_network_ids]
+
     def fetch_for_device(device):
         if device['model'].startswith('MS'):
             return _get_fixed_ip_assignments_from_switch(dashboard, device)


### PR DESCRIPTION
* **💡 What:** Added logic to filter the list of Meraki devices by the selected `meraki_network_ids` before spawning threads to fetch their specific IP assignments.
* **🎯 Why:** Previously, `ThreadPoolExecutor` fetched data for all devices in the organization, causing an N+1 API call issue for devices that belonged to unselected networks. This optimization prevents those unnecessary API calls.
* **📊 Impact:** Reduces latency and Meraki dashboard API usage, especially for large organizations where only specific networks are being synchronized.
* **🔬 Measurement:** Review Meraki API usage logs. The number of `/devices/{serial}/switch/routing/interfaces` or `/networks/{networkId}/appliance/vlans` calls should be proportionally reduced relative to the number of ignored networks.

---
*PR created automatically by Jules for task [877552076753834991](https://jules.google.com/task/877552076753834991) started by @brewmarsh*