### PR TITLE
🎨 Palette: Add lang and viewport meta tags for accessibility and mobile responsiveness

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,6 @@
 ## 2026-07-26 - Accessible Scrollable Regions
 **Learning:** Elements with scrollable overflow (like `<pre class="log-box">`) are not natively focusable by default, meaning keyboard-only users cannot scroll their content using arrow keys.
 **Action:** Always add `tabindex="0"` to visually scrollable regions and include a visible `:focus-visible` outline for sighted keyboard users to ensure they are fully accessible and usable.
+## 2026-07-29 - Missing language attribute and viewport meta tags
+**Learning:** HTML templates (like index.html, 404.html, and 500.html) should always include a `lang="en"` attribute on the `<html>` tag to allow screen readers to use the correct pronunciation rules. Additionally, adding a `<meta name="viewport" content="width=device-width, initial-scale=1.0">` tag is a foundational requirement for making web pages responsive and legible on mobile devices. Adding `<meta charset="UTF-8">` ensures consistent text encoding across browsers.
+**Action:** Always verify the presence of the `lang` attribute and essential `<meta>` tags (charset and viewport) in all HTML templates, especially error pages which are often overlooked but still need to be accessible and responsive.

--- a/app/templates/404.html
+++ b/app/templates/404.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Page Not Found</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
 </head>

--- a/app/templates/500.html
+++ b/app/templates/500.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Internal Server Error</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
 </head>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Meraki Pi-hole Sync</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="/static/style.css">


### PR DESCRIPTION
💡 **What**: Added `lang="en"` to the `<html>` tag and included `<meta charset="UTF-8">` and `<meta name="viewport" content="width=device-width, initial-scale=1.0">` inside the `<head>` of `index.html`, `404.html`, and `500.html`.

🎯 **Why**: 
1. Missing the `lang` attribute prevents screen readers from determining the correct pronunciation rules, degrading accessibility for visually impaired users.
2. Without the viewport meta tag, mobile devices try to render the page at desktop widths, causing the UI to appear tiny and requiring horizontal scrolling, resulting in poor mobile UX.
3. Adding the charset meta tag ensures consistent text encoding across all browsers.

📸 **Before/After**: 
* Before: `<html>` missing `lang` attribute, `<head>` missing viewport and charset `<meta>` tags.
* After: `<html lang="en">`, `<head>` includes `<meta charset="UTF-8">` and `<meta name="viewport" content="width=device-width, initial-scale=1.0">`.

♿ **Accessibility**: Setting the HTML `lang` attribute fulfills a fundamental WCAG success criterion, allowing screen readers to function correctly. The viewport tag ensures the page scales properly, which is also an accessibility consideration for users who need readable text without constant zooming and panning on smaller screens.

---
*PR created automatically by Jules for task [15265033667985746768](https://jules.google.com/task/15265033667985746768) started by @brewmarsh*