### PR TITLE
🎨 Palette: Add skip to main content link

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,6 +11,7 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
     {% if show_welcome_banner %}
     <div id="welcome-screen" role="dialog" aria-modal="true" aria-labelledby="welcome-title">
         <div class="card">
@@ -47,7 +48,7 @@
         </div>
     </nav>
 
-    <div class="container">
+    <main id="main-content" class="container" tabindex="-1" style="outline: none;">
         <div class="row mt-4">
             <div class="col-md-8">
                 <div class="card mt-4" id="charts-card">
@@ -172,7 +173,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    </main>
 
     <div class="toast-container position-fixed bottom-0 end-0 p-3">
       <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">


### PR DESCRIPTION
💡 What:
Added a "Skip to main content" link at the very top of the page. It is visually hidden by default but becomes visible when it receives keyboard focus. It targets the main content area, which was converted from a standard `<div>` to a semantic `<main>` tag with `tabindex="-1"` to properly support programmatic focus.

🎯 Why:
To improve keyboard navigation and overall accessibility. Users navigating via keyboard (or screen readers) often have to tab through repetitive navigation links on every page load. This provides a quick shortcut directly to the primary content of the page.

📸 Before/After:
Before: Keyboard users had to tab through the navigation elements before reaching the charts and controls.
After: The first tab press focuses the "Skip to main content" link, allowing users to immediately jump to the core application area.

♿ Accessibility:
This is a standard accessibility best practice. It provides a bypass mechanism (WCAG 2.4.1 Bypass Blocks) and improves semantic HTML by using the `<main>` element to define the primary content area.

---
*PR created automatically by Jules for task [17642990039910933406](https://jules.google.com/task/17642990039910933406) started by @brewmarsh*