### PR TITLE
🎨 Palette: Add skip to content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,6 @@
 ## 2026-07-26 - Accessible Scrollable Regions
 **Learning:** Elements with scrollable overflow (like `<pre class="log-box">`) are not natively focusable by default, meaning keyboard-only users cannot scroll their content using arrow keys.
 **Action:** Always add `tabindex="0"` to visually scrollable regions and include a visible `:focus-visible` outline for sighted keyboard users to ensure they are fully accessible and usable.
+## 2026-07-31 - Accessible Skip to Content Links
+**Learning:** Adding a "Skip to main content" link is a huge accessibility win for keyboard users. To implement it correctly with Bootstrap, use the `visually-hidden-focusable` class on an anchor link positioned at the top of the body. Crucially, the target container must use the semantic `<main>` tag, have `tabindex="-1"` so it can programmatically receive focus when the link is clicked, and `outline: none` to prevent an ugly browser focus ring around the entire page content.
+**Action:** Always implement skip-to-content links on pages with global navigation, ensuring the target container is appropriately configured to receive focus without displaying a default focus outline.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,6 +11,7 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="visually-hidden-focusable p-3 bg-primary text-white position-absolute top-0 start-0 z-3">Skip to main content</a>
     {% if show_welcome_banner %}
     <div id="welcome-screen" role="dialog" aria-modal="true" aria-labelledby="welcome-title">
         <div class="card">
@@ -47,7 +48,7 @@
         </div>
     </nav>
 
-    <div class="container">
+    <main id="main-content" class="container" tabindex="-1" style="outline: none;">
         <div class="row mt-4">
             <div class="col-md-8">
                 <div class="card mt-4" id="charts-card">
@@ -172,7 +173,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    </main>
 
     <div class="toast-container position-fixed bottom-0 end-0 p-3">
       <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">


### PR DESCRIPTION
💡 What: Added a 'Skip to main content' link that appears visually on focus, along with converting the container to a focusable main content area.

🎯 Why: Users navigating with keyboards or screen readers often have to tab through repetitive global navigation links before reaching the main content. This skips that repetitive navigation.

📸 Before/After: The link remains hidden visually to mouse users. When tabbed to, a highly visible block containing 'Skip to main content' appears in the top-left of the screen.

♿ Accessibility:
- Added `visually-hidden-focusable` link at the start of `<body>`.
- Changed primary content `<div class="container">` to `<main id="main-content" class="container" tabindex="-1" style="outline: none;">` to allow programmatic focus without displaying an ugly browser default focus ring on the entire page content.
- Improves efficiency and UX for assistive technologies.

---
*PR created automatically by Jules for task [6152493543023239843](https://jules.google.com/task/6152493543023239843) started by @brewmarsh*