### PR TITLE
🎨 Palette: Add skip to main content link and mobile viewport meta

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,6 @@
 ## 2026-07-26 - Accessible Scrollable Regions
 **Learning:** Elements with scrollable overflow (like `<pre class="log-box">`) are not natively focusable by default, meaning keyboard-only users cannot scroll their content using arrow keys.
 **Action:** Always add `tabindex="0"` to visually scrollable regions and include a visible `:focus-visible` outline for sighted keyboard users to ensure they are fully accessible and usable.
+## 2024-08-01 - Skip to Main Content and Semantic Main Region
+**Learning:** For keyboard and screen reader accessibility, users need a way to bypass repetitive navigation links (like the navbar) and jump directly to the primary content of the application. However, using a `<main>` container with `tabindex="-1"` is essential to allow this semantic landmark to receive programmatic focus when the skip link is activated, while `outline: none;` prevents an unsightly visual focus ring around the entire application body for mouse users.
+**Action:** Always implement a 'Skip to main content' link (using Bootstrap's `visually-hidden-focusable`) at the top of the `<body>`, and ensure it targets a `<main id="main-content" tabindex="-1" style="outline: none;">` tag to properly manage focus for keyboard navigation.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Meraki Pi-hole Sync</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="/static/style.css">
@@ -11,6 +12,7 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
     {% if show_welcome_banner %}
     <div id="welcome-screen" role="dialog" aria-modal="true" aria-labelledby="welcome-title">
         <div class="card">
@@ -47,7 +49,7 @@
         </div>
     </nav>
 
-    <div class="container">
+    <main id="main-content" class="container" tabindex="-1" style="outline: none;">
         <div class="row mt-4">
             <div class="col-md-8">
                 <div class="card mt-4" id="charts-card">
@@ -172,7 +174,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    </main>
 
     <div class="toast-container position-fixed bottom-0 end-0 p-3">
       <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">


### PR DESCRIPTION
💡 **What**: Added an accessible 'Skip to main content' link, a `lang="en"` attribute to the `<html>` tag, and a mobile-responsive viewport `<meta>` tag to `index.html`. Also updated the primary `div.container` to a semantic `<main>` tag with `tabindex="-1"`.
🎯 **Why**: To significantly improve keyboard navigation and screen-reader usability, allowing users to bypass repetitive navigation elements, as well as fixing structural accessibility and mobile rendering behavior.
📸 **Before/After**: The "Skip to main content" link is visually hidden for mouse users but becomes visible and functional when focused via the keyboard `Tab` key.
♿ **Accessibility**: Provides robust semantic landmarks, manages keyboard focus correctly without introducing visible focus rings on the main body container, and declares page language explicitly for screen readers.

---
*PR created automatically by Jules for task [3866177032066736280](https://jules.google.com/task/3866177032066736280) started by @brewmarsh*