### PR TITLE
🎨 Palette: Add Skip to Main Content Link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,6 @@
 ## 2026-07-26 - Accessible Scrollable Regions
 **Learning:** Elements with scrollable overflow (like `<pre class="log-box">`) are not natively focusable by default, meaning keyboard-only users cannot scroll their content using arrow keys.
 **Action:** Always add `tabindex="0"` to visually scrollable regions and include a visible `:focus-visible` outline for sighted keyboard users to ensure they are fully accessible and usable.
+## 2026-08-02 - Keyboard Accessibility Skip Links
+**Learning:** For users relying on keyboard navigation, long or complex navigation headers can be tedious to bypass. Providing a 'Skip to main content' link that is visually hidden until focused significantly improves UX and accessibility.
+**Action:** Always include a 'Skip to main content' link pointing to an interactive `<main>` or primary content container using `visually-hidden-focusable` (in Bootstrap) and `tabindex="-1"` on the target container.

--- a/app/templates/docs.html
+++ b/app/templates/docs.html
@@ -7,11 +7,12 @@
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-    <div class="container">
+    <a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
+    <main id="main-content" class="container" tabindex="-1" style="outline: none;">
         <a href="/"><h1>Meraki Pi-hole Sync</h1></a>
         <div class="log-container">
             {{ content|safe }}
         </div>
-    </div>
+    </main>
 </body>
 </html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,6 +11,7 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
     {% if show_welcome_banner %}
     <div id="welcome-screen" role="dialog" aria-modal="true" aria-labelledby="welcome-title">
         <div class="card">
@@ -47,7 +48,7 @@
         </div>
     </nav>
 
-    <div class="container">
+    <main id="main-content" class="container" tabindex="-1" style="outline: none;">
         <div class="row mt-4">
             <div class="col-md-8">
                 <div class="card mt-4" id="charts-card">
@@ -172,7 +173,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    </main>
 
     <div class="toast-container position-fixed bottom-0 end-0 p-3">
       <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">


### PR DESCRIPTION
💡 What: Added a 'Skip to main content' link that is visually hidden until focused. Changed the main generic container `<div class="container">` to a semantic `<main>` tag with proper attributes.
🎯 Why: Keyboard and screen-reader users need a way to easily bypass repetitive navigation headers.
📸 Before/After: Verified via Playwright.
♿ Accessibility: Significant improvement for keyboard navigation by ensuring the main content can be easily reached and programmatically focused.

---
*PR created automatically by Jules for task [8590759576001467254](https://jules.google.com/task/8590759576001467254) started by @brewmarsh*