### PR TITLE
⚡ Bolt: Extract loop-invariant dictionary lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,6 @@
 ## 2025-10-28 - Caching Configuration Parsing
 **Learning:** Functions that parse environment variables and construct configuration objects can introduce redundant overhead when called repeatedly in hot loops (like SSE streams). Bypassing them with direct `os.getenv()` calls is an anti-pattern as it breaks centralized configuration and mocked tests.
 **Action:** Use `@functools.lru_cache(maxsize=1)` on the central configuration loading function (e.g., `load_app_config_from_env`) to safely cache the parsed results and eliminate redundant processing overhead without fracturing configuration management.
+## 2025-10-29 - Extract loop-invariant dictionary lookups
+**Learning:** Found redundant dictionary lookups (e.g. `config['hostname_suffix']`) inside hot loops iterating over `meraki_clients` and `existing_pihole_records` in `sync_pihole_dns`. Accessing dictionary values inside a loop requires hashing the key on every iteration, which is an O(1) operation but adds up in tight loops over large arrays, becoming a performance bottleneck.
+**Action:** Extract the loop-invariant dictionary lookup into a local variable before the loops and reference the local variable inside.

--- a/app/sync_logic.py
+++ b/app/sync_logic.py
@@ -220,6 +220,10 @@ def sync_pihole_dns(update_type=None):
             if not changelog_path.exists():
                 changelog_path.touch()
 
+            # ⚡ Bolt Optimization: Extract loop-invariant dictionary lookups
+            # Impact: Prevents redundant hashing operations on every iteration.
+            hostname_suffix = config['hostname_suffix']
+
             with changelog_path.open("a+") as f:
                 f.seek(0)
                 previous_mappings = f.readlines()
@@ -241,7 +245,7 @@ def sync_pihole_dns(update_type=None):
                         continue
 
                     client_name_sanitized = client_name.replace(" ", "-").lower()
-                    domain_to_sync = f"{client_name_sanitized}{config['hostname_suffix']}"
+                    domain_to_sync = f"{client_name_sanitized}{hostname_suffix}"
                     ip_to_sync = client["ip"]
 
                     # Bolt: Pass existing_pihole_records to avoid an API call (N+1 query problem) on every client
@@ -262,7 +266,7 @@ def sync_pihole_dns(update_type=None):
                         )
 
                 for domain, ip in existing_pihole_records.items():
-                    pihole_hostname = domain.replace(config['hostname_suffix'], "")
+                    pihole_hostname = domain.replace(hostname_suffix, "")
                     if ip not in meraki_clients_by_ip and pihole_hostname not in meraki_clients_by_name:
                         if pihole_client.remove_dns_record(domain, ip):
                             timestamp = datetime.now()
@@ -282,7 +286,7 @@ def sync_pihole_dns(update_type=None):
             for client in meraki_clients:
                 if client.get("name"):
                     client_name_sanitized = client["name"].replace(" ", "-").lower()
-                    domain_to_sync = f"{client_name_sanitized}{config['hostname_suffix']}"
+                    domain_to_sync = f"{client_name_sanitized}{hostname_suffix}"
                     if domain_to_sync in existing_pihole_records:
                         mapped_devices += 1
                     else:


### PR DESCRIPTION
💡 What: Extracted `config['hostname_suffix']` into a local variable before hot loops in `sync_pihole_dns`.
🎯 Why: Accessing a dictionary inside a loop causes redundant string hashing operations on every single iteration, which becomes a bottleneck when iterating over large arrays of devices.
📊 Impact: Speed up the execution of the hot loops over `meraki_clients` and `existing_pihole_records`.
🔬 Measurement: Compare the time taken by `sync_pihole_dns` for thousands of clients before and after.

---
*PR created automatically by Jules for task [7068261666359060696](https://jules.google.com/task/7068261666359060696) started by @brewmarsh*