### PR TITLE
🎨 Palette: Add skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,6 @@
 ## 2026-07-26 - Accessible Scrollable Regions
 **Learning:** Elements with scrollable overflow (like `<pre class="log-box">`) are not natively focusable by default, meaning keyboard-only users cannot scroll their content using arrow keys.
 **Action:** Always add `tabindex="0"` to visually scrollable regions and include a visible `:focus-visible` outline for sighted keyboard users to ensure they are fully accessible and usable.
+## 2026-08-03 - Skip to main content accessibility
+**Learning:** For keyboard-only and screen-reader users, having a "Skip to main content" link at the top of the body helps them easily bypass repetitive navigation elements. By targeting a main content area with `id="main-content"`, `tabindex="-1"`, and `style="outline: none;"`, focus is correctly passed down for interaction without leaving an unsightly default focus ring.
+**Action:** When working on new layouts, ensure a visually-hidden-focusable skip link is added at the top of the body referencing a properly marked main container.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,6 +11,7 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
     {% if show_welcome_banner %}
     <div id="welcome-screen" role="dialog" aria-modal="true" aria-labelledby="welcome-title">
         <div class="card">
@@ -47,7 +48,7 @@
         </div>
     </nav>
 
-    <div class="container">
+    <main class="container" id="main-content" tabindex="-1" style="outline: none;">
         <div class="row mt-4">
             <div class="col-md-8">
                 <div class="card mt-4" id="charts-card">
@@ -172,7 +173,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    </main>
 
     <div class="toast-container position-fixed bottom-0 end-0 p-3">
       <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">


### PR DESCRIPTION
💡 **What**: Added a visually hidden 'Skip to main content' link at the top of the body that becomes visible when focused, and changed the primary content wrapper from a `div` to a semantic `<main>` tag with appropriate screen reader attributes.
🎯 **Why**: Keyboard-only and screen-reader users need a way to easily bypass repetitive navigation elements.
📸 **Before/After**: (See UI verification step for screenshot of focus state).
♿ **Accessibility**: Provides immediate keyboard bypass for the navbar directly to the core application content, preventing tedious tabbing.

---
*PR created automatically by Jules for task [12294772818459697476](https://jules.google.com/task/12294772818459697476) started by @brewmarsh*