### PR TITLE
⚡ Bolt: Filter devices by network ID before concurrent fetching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,6 @@
 ## 2025-10-28 - Caching Configuration Parsing
 **Learning:** Functions that parse environment variables and construct configuration objects can introduce redundant overhead when called repeatedly in hot loops (like SSE streams). Bypassing them with direct `os.getenv()` calls is an anti-pattern as it breaks centralized configuration and mocked tests.
 **Action:** Use `@functools.lru_cache(maxsize=1)` on the central configuration loading function (e.g., `load_app_config_from_env`) to safely cache the parsed results and eliminate redundant processing overhead without fracturing configuration management.
+## 2025-10-29 - Prevent unnecessary work by filtering before multithreading
+**Learning:** Found an N+1 query problem where `ThreadPoolExecutor` processed all devices without pre-filtering by user-selected `network_ids`. This triggered expensive and unnecessary HTTP API calls to fetch IPs for devices on unselected networks.
+**Action:** When working with a list of items to be processed concurrently (e.g., using `ThreadPoolExecutor`), always filter the items beforehand if possible, rather than discarding the results inside the thread or iterating blindly. This prevents redundant work and external API requests.

--- a/app/clients/meraki_client.py
+++ b/app/clients/meraki_client.py
@@ -89,6 +89,12 @@ def get_all_relevant_meraki_clients(dashboard: meraki.DashboardAPI, config: dict
             return _get_fixed_ip_assignments_from_appliance(dashboard, device)
         return []
 
+    # ⚡ Bolt Optimization: Filter devices by network ID before fanning out to the worker pool.
+    # Impact: Prevents N+1 API calls for devices in unselected networks, significantly reducing unnecessary external HTTP requests and saving time.
+    network_ids = config.get("meraki_network_ids", [])
+    if network_ids:
+        devices = [d for d in devices if d.get("networkId") in network_ids]
+
     # Use a ThreadPoolExecutor to fetch device data in parallel
     with ThreadPoolExecutor(max_workers=10) as executor:
         futures = [executor.submit(fetch_for_device, device) for device in devices]


### PR DESCRIPTION
💡 What: Added pre-filtering of devices by `network_ids` before offloading them to `ThreadPoolExecutor` in `get_all_relevant_meraki_clients`.
🎯 Why: Previously, the script submitted all devices in an organization to the thread pool, triggering an external HTTP API call (`fetch_for_device`) for each. When users provided specific `network_ids` to sync, checking unselected networks was a massive waste of API calls (an N+1 query problem).
📊 Impact: Completely eliminates N+1 API calls for devices in unselected networks, significantly reducing execution time during large organizational syncs.
🔬 Measurement: Run a synchronization job with limited `network_ids` specified on a large Meraki organization, and measure the wall-clock time compared to before.

---
*PR created automatically by Jules for task [18273937122716094571](https://jules.google.com/task/18273937122716094571) started by @brewmarsh*