### PR TITLE
🎨 Palette: Add 'Skip to main content' link for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,7 @@
 ## 2026-07-26 - Accessible Scrollable Regions
 **Learning:** Elements with scrollable overflow (like `<pre class="log-box">`) are not natively focusable by default, meaning keyboard-only users cannot scroll their content using arrow keys.
 **Action:** Always add `tabindex="0"` to visually scrollable regions and include a visible `:focus-visible` outline for sighted keyboard users to ensure they are fully accessible and usable.
+
+## 2024-08-04 - Skip to main content links
+**Learning:** When implementing a 'Skip to main content' link for keyboard accessibility, it must be placed at the top of the body using Bootstrap's 'visually-hidden-focusable' class and ensure it targets a focusable '<main>' container with 'tabindex="-1"' and 'outline: none;'.
+**Action:** Always include a 'Skip to main content' link that targets a focusable main container when modifying layout templates, to enable keyboard users to bypass repetitive navigation elements.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,6 +11,7 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
     {% if show_welcome_banner %}
     <div id="welcome-screen" role="dialog" aria-modal="true" aria-labelledby="welcome-title">
         <div class="card">
@@ -47,7 +48,7 @@
         </div>
     </nav>
 
-    <div class="container">
+    <main id="main-content" class="container" tabindex="-1" style="outline: none;">
         <div class="row mt-4">
             <div class="col-md-8">
                 <div class="card mt-4" id="charts-card">
@@ -172,7 +173,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    </main>
 
     <div class="toast-container position-fixed bottom-0 end-0 p-3">
       <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">


### PR DESCRIPTION
💡 What: Added a 'Skip to main content' link hidden visibly but accessible via keyboard focus. Changed the main layout container to a `<main>` tag with appropriate tabindex properties.

🎯 Why: Keyboard-only users and screen reader users frequently need to bypass repetitive navigation elements to reach the main content quickly.

📸 Before/After: Verified via Playwright screenshot that the skip link appears when tabbed into.

♿ Accessibility: Ensures that keyboard users have a direct way to navigate to the primary content without tabbing through every element in the navbar.

---
*PR created automatically by Jules for task [634646446509376892](https://jules.google.com/task/634646446509376892) started by @brewmarsh*