### PR TITLE
🎨 Palette: Add skip-to-content link for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,7 @@
 ## 2026-07-26 - Accessible Scrollable Regions
 **Learning:** Elements with scrollable overflow (like `<pre class="log-box">`) are not natively focusable by default, meaning keyboard-only users cannot scroll their content using arrow keys.
 **Action:** Always add `tabindex="0"` to visually scrollable regions and include a visible `:focus-visible` outline for sighted keyboard users to ensure they are fully accessible and usable.
+
+## 2024-08-05 - Adding skip-to-content links for keyboard accessibility
+**Learning:** Adding a "Skip to main content" link significantly improves the accessibility for keyboard users and those utilizing screen readers by allowing them to bypass repetitive navigation links.
+**Action:** Always implement a visually-hidden, focusable skip link at the top of the body element, and ensure it targets a focusable `<main>` container with `tabindex="-1"` and `outline: none;` to ensure smooth keyboard navigation.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,6 +11,7 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
     {% if show_welcome_banner %}
     <div id="welcome-screen" role="dialog" aria-modal="true" aria-labelledby="welcome-title">
         <div class="card">
@@ -47,7 +48,7 @@
         </div>
     </nav>
 
-    <div class="container">
+    <main id="main-content" class="container" tabindex="-1" style="outline: none;">
         <div class="row mt-4">
             <div class="col-md-8">
                 <div class="card mt-4" id="charts-card">
@@ -172,7 +173,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    </main>
 
     <div class="toast-container position-fixed bottom-0 end-0 p-3">
       <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">


### PR DESCRIPTION
💡 What: Added a 'Skip to main content' link at the top of the body tag that targets a focusable '<main>' container.
🎯 Why: To significantly improve accessibility for keyboard and screen reader users by allowing them to bypass repetitive navigation elements.
📸 Before/After: Visual changes are hidden unless a user is navigating via keyboard, where they will see the skip link appear on focus at the top left of the screen.
♿ Accessibility: Improves WCAG compliance by providing a bypass block mechanism for repetitive content.

---
*PR created automatically by Jules for task [7384343430392661319](https://jules.google.com/task/7384343430392661319) started by @brewmarsh*