### PR TITLE
⚡ Bolt: Move inline import to module level

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,6 @@
 ## 2025-10-28 - Caching Configuration Parsing
 **Learning:** Functions that parse environment variables and construct configuration objects can introduce redundant overhead when called repeatedly in hot loops (like SSE streams). Bypassing them with direct `os.getenv()` calls is an anti-pattern as it breaks centralized configuration and mocked tests.
 **Action:** Use `@functools.lru_cache(maxsize=1)` on the central configuration loading function (e.g., `load_app_config_from_env`) to safely cache the parsed results and eliminate redundant processing overhead without fracturing configuration management.
+## 2025-10-30 - Inline Imports in Frequently Called Functions
+**Learning:** Found an inline `import json` inside the `sync_pihole_dns` function, which is called frequently in a loop by the background runner. While Python caches modules in `sys.modules`, executing an import statement inside a function still incurs a small dictionary lookup and namespace binding overhead on every call.
+**Action:** Move inline module imports to the top level of the file unless there is a specific reason (like avoiding circular dependencies or lazy loading a heavy module) to keep them inline. This prevents redundant overhead in hot functions.

--- a/app/sync_logic.py
+++ b/app/sync_logic.py
@@ -1,4 +1,5 @@
 import functools
+import json
 import os
 import sys
 import time
@@ -293,7 +294,8 @@ def sync_pihole_dns(update_type=None):
                 f.write(f"{int(time.time())},{mapped_devices}\n")
 
             with Path(config["cache_file_path"]).open("w") as f:
-                import json
+                # ⚡ Bolt Optimization: Moved `import json` to module level
+                # Impact: Avoids dictionary lookup overhead in sys.modules during hot loop function execution
                 json.dump({
                     "pihole": existing_pihole_records,
                     "meraki": meraki_clients,


### PR DESCRIPTION
💡 What: Moved the inline `import json` within the frequently called `sync_pihole_dns` function (in `app/sync_logic.py`) to the module level.
🎯 Why: While Python caches imported modules in `sys.modules`, executing the import statement inside a hot loop function still incurs a small dictionary lookup and namespace binding overhead on every single iteration/call. Moving it outside avoids this redundant operation.
📊 Impact: Prevents a redundant dictionary lookup on every invocation of the background sync worker.
🔬 Measurement: Verify using `git diff` and reviewing the updated code structure in `app/sync_logic.py`.

---
*PR created automatically by Jules for task [3904061228656229760](https://jules.google.com/task/3904061228656229760) started by @brewmarsh*