### PR TITLE
⚡ Bolt: Add pre-filtering before fan-out to prevent N+1 API calls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,6 @@
 ## 2025-10-28 - Caching Configuration Parsing
 **Learning:** Functions that parse environment variables and construct configuration objects can introduce redundant overhead when called repeatedly in hot loops (like SSE streams). Bypassing them with direct `os.getenv()` calls is an anti-pattern as it breaks centralized configuration and mocked tests.
 **Action:** Use `@functools.lru_cache(maxsize=1)` on the central configuration loading function (e.g., `load_app_config_from_env`) to safely cache the parsed results and eliminate redundant processing overhead without fracturing configuration management.
+## 2025-10-29 - Prevent N+1 API calls when fanning out
+**Learning:** Found an N+1 query problem where the list of devices fetched from the Meraki Dashboard was fanned out directly to a thread pool to perform concurrent API calls. When a `meraki_network_ids` filter is provided in configuration, performing the filtering inside the thread or skipping results after fetching incurs an unnecessary external HTTP request overhead per device.
+**Action:** Always filter data collections (e.g., filtering devices by network ID) *before* fanning them out to worker pools like `ThreadPoolExecutor` to avoid unnecessary external HTTP requests and prevent N+1 API call problems.

--- a/app/clients/meraki_client.py
+++ b/app/clients/meraki_client.py
@@ -88,6 +88,10 @@ def get_all_relevant_meraki_clients(dashboard: meraki.DashboardAPI, config: dict
         elif device['model'].startswith('MX'):
             return _get_fixed_ip_assignments_from_appliance(dashboard, device)
         return []
+    # ⚡ Bolt Optimization: Filter devices by network ID before fanning out to prevent N+1 API calls
+    if config.get("meraki_network_ids"):
+        devices = [d for d in devices if d.get('networkId') in config['meraki_network_ids']]
+
 
     # Use a ThreadPoolExecutor to fetch device data in parallel
     with ThreadPoolExecutor(max_workers=10) as executor:


### PR DESCRIPTION
💡 What: Added early filtering of the `devices` list in `get_all_relevant_meraki_clients` so that devices not matching the configured `meraki_network_ids` are skipped before they are sent to the `ThreadPoolExecutor`.

🎯 Why: Previously, the script would fan out all devices to the thread pool and then make external Meraki API calls to fetch fixed IP assignments, even if the device was in a network we didn't care about. This caused a massive N+1 query problem and wasted API quota/time.

📊 Impact: Reduces the number of Meraki API calls dramatically for large organizations that only want to sync a subset of their networks. The sync time should decrease linearly with the number of skipped devices.

🔬 Measurement: Test with a large organization but a small `meraki_network_ids` list. The sync process should finish much faster and log significantly fewer HTTP requests.

---
*PR created automatically by Jules for task [2670637927311610842](https://jules.google.com/task/2670637927311610842) started by @brewmarsh*