### PR TITLE
🎨 Palette: Add skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,7 @@
 ## 2026-07-26 - Accessible Scrollable Regions
 **Learning:** Elements with scrollable overflow (like `<pre class="log-box">`) are not natively focusable by default, meaning keyboard-only users cannot scroll their content using arrow keys.
 **Action:** Always add `tabindex="0"` to visually scrollable regions and include a visible `:focus-visible` outline for sighted keyboard users to ensure they are fully accessible and usable.
+
+## 2024-08-06 - Accessibility Skip to Main Content
+**Learning:** Adding a "Skip to main content" link is a critical accessibility feature for keyboard users, allowing them to bypass repetitive navigation elements. To function correctly, it must be the first focusable element, visually hidden until focused (e.g., using Bootstrap's `.visually-hidden-focusable`), and target a `<main>` container with `tabindex="-1"` and `outline: none;` so it can receive programmatic focus without displaying an ugly focus ring.
+**Action:** Always implement a skip-to-content link targeting the primary `<main>` content container when building application layouts, ensuring the target has `tabindex="-1"` and `outline: none;` to handle focus correctly.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,6 +11,7 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
     {% if show_welcome_banner %}
     <div id="welcome-screen" role="dialog" aria-modal="true" aria-labelledby="welcome-title">
         <div class="card">
@@ -47,7 +48,7 @@
         </div>
     </nav>
 
-    <div class="container">
+    <main id="main-content" class="container" tabindex="-1" style="outline: none;">
         <div class="row mt-4">
             <div class="col-md-8">
                 <div class="card mt-4" id="charts-card">
@@ -172,7 +173,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    </main>
 
     <div class="toast-container position-fixed bottom-0 end-0 p-3">
       <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">

--- a/pr_desc.txt
+++ b/pr_desc.txt
@@ -1,0 +1,9 @@
+💡 What: Added a visually hidden "Skip to main content" link as the first focusable element on the page, and updated the main container to semantically use `<main>` with programmatic focus support (`tabindex="-1"` and `outline: none;`).
+
+🎯 Why: Keyboard-only users and screen reader users often have to repeatedly tab through the same navigation elements (like the navbar) on every page reload or visit. A "skip link" allows them to jump directly to the primary content, significantly improving efficiency and usability.
+
+📸 Before/After: See generated frontend verification videos/screenshots. The link is invisible to mouse users but appears at the top left when focused via the `Tab` key.
+
+♿ Accessibility: Directly satisfies WCAG Guideline 2.4.1 (Bypass Blocks).
+
+Recorded learning about skip link implementation details in `.Jules/palette.md`.


### PR DESCRIPTION
💡 What: Added a visually hidden "Skip to main content" link as the first focusable element on the page, and updated the main container to semantically use `<main>` with programmatic focus support (`tabindex="-1"` and `outline: none;`).

🎯 Why: Keyboard-only users and screen reader users often have to repeatedly tab through the same navigation elements (like the navbar) on every page reload or visit. A "skip link" allows them to jump directly to the primary content, significantly improving efficiency and usability.

📸 Before/After: See generated frontend verification videos/screenshots. The link is invisible to mouse users but appears at the top left when focused via the `Tab` key.

♿ Accessibility: Directly satisfies WCAG Guideline 2.4.1 (Bypass Blocks).

Recorded learning about skip link implementation details in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [4160478293092729909](https://jules.google.com/task/4160478293092729909) started by @brewmarsh*