### PR TITLE
🎨 Palette: Add skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,7 @@
 ## 2026-07-26 - Accessible Scrollable Regions
 **Learning:** Elements with scrollable overflow (like `<pre class="log-box">`) are not natively focusable by default, meaning keyboard-only users cannot scroll their content using arrow keys.
 **Action:** Always add `tabindex="0"` to visually scrollable regions and include a visible `:focus-visible` outline for sighted keyboard users to ensure they are fully accessible and usable.
+
+## 2024-08-07 - Skip to main content accessibility
+**Learning:** Adding a "Skip to main content" link is a quick and extremely effective way to improve keyboard navigation accessibility, especially in apps with extensive top navigation. When implementing, the target container (e.g., `<main>`) must have `tabindex="-1"` and `style="outline: none;"` so it can programmatically receive focus from the link without showing an ugly focus ring or entering the regular tab order.
+**Action:** Always include a `.visually-hidden-focusable` skip link targeting a `<main>` container configured with `tabindex="-1"` and `outline: none` at the top of application layout files.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,6 +11,7 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="visually-hidden-focusable p-3">Skip to main content</a>
     {% if show_welcome_banner %}
     <div id="welcome-screen" role="dialog" aria-modal="true" aria-labelledby="welcome-title">
         <div class="card">
@@ -47,7 +48,7 @@
         </div>
     </nav>
 
-    <div class="container">
+    <main id="main-content" class="container" tabindex="-1" style="outline: none;">
         <div class="row mt-4">
             <div class="col-md-8">
                 <div class="card mt-4" id="charts-card">
@@ -183,7 +184,7 @@
         <div class="toast-body">
         </div>
       </div>
-    </div>
+    </main>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>


### PR DESCRIPTION
💡 What: Added a "Skip to main content" link at the very top of the application body.

🎯 Why: To improve accessibility for keyboard-only and screen reader users by allowing them to bypass the navigation and skip directly to the primary content on the page. 

📸 Before/After: This is a visually hidden change for mouse users, but it becomes visible and focusable when navigating the top of the page with the keyboard.

♿ Accessibility: Added a "Skip to main content" link using Bootstrap's `.visually-hidden-focusable` class targeting a semantic `<main>` tag. The target `<main>` tag was also added (replacing the primary `<div class="container">`) with `tabindex="-1"` and `outline: none;` to properly receive programmatic focus.

---
*PR created automatically by Jules for task [14923046056466566267](https://jules.google.com/task/14923046056466566267) started by @brewmarsh*