### PR TITLE
⚡ Bolt: Prevent N+1 API calls by pre-filtering collections

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,6 @@
 ## 2025-10-28 - Caching Configuration Parsing
 **Learning:** Functions that parse environment variables and construct configuration objects can introduce redundant overhead when called repeatedly in hot loops (like SSE streams). Bypassing them with direct `os.getenv()` calls is an anti-pattern as it breaks centralized configuration and mocked tests.
 **Action:** Use `@functools.lru_cache(maxsize=1)` on the central configuration loading function (e.g., `load_app_config_from_env`) to safely cache the parsed results and eliminate redundant processing overhead without fracturing configuration management.
+## 2025-11-20 - Prevent N+1 API calls by pre-filtering collections
+**Learning:** Found an N+1 API call problem where an entire organization's devices were passed to a `ThreadPoolExecutor` to fetch fixed IP assignments, even when `meraki_network_ids` was specified to filter the results. This caused unnecessary external HTTP requests for devices outside the target networks.
+**Action:** Always filter data collections (e.g., filtering devices by network ID) *before* fanning them out to concurrent executors like `ThreadPoolExecutor`. This prevents unnecessary external HTTP requests and significantly speeds up processing.

--- a/app/clients/meraki_client.py
+++ b/app/clients/meraki_client.py
@@ -82,6 +82,12 @@ def get_all_relevant_meraki_clients(dashboard: meraki.DashboardAPI, config: dict
         log.error("Meraki API error while fetching organization devices", error=e, org_id=org_id)
         return []
 
+
+    # ⚡ Bolt Optimization: Filter the devices list before fanning out to the thread pool
+    # to prevent N+1 API calls for devices outside the target networks.
+    target_network_ids = config.get("meraki_network_ids")
+    if target_network_ids:
+        devices = [d for d in devices if d.get('networkId') in target_network_ids]
     def fetch_for_device(device):
         if device['model'].startswith('MS'):
             return _get_fixed_ip_assignments_from_switch(dashboard, device)


### PR DESCRIPTION
💡 What: Filter the `devices` collection by `meraki_network_ids` before fanning out HTTP requests via `ThreadPoolExecutor`.

🎯 Why: Previously, the application fetched devices for the entire organization and then passed all of them to the thread pool to fetch fixed IP assignments. If `meraki_network_ids` was specified, this resulted in unnecessary N+1 external API requests to the Meraki dashboard for devices outside the target networks.

📊 Impact: Significantly reduces the number of outbound Meraki API calls during sync runs for large organizations that only target specific networks, resulting in much faster completion times and reduced risk of rate-limiting.

🔬 Measurement: Observe the number of Meraki API calls made during a sync run when a subset of networks is specified in `meraki_network_ids`. The number of calls to `/devices/{serial}/switch/routing/interfaces` or similar endpoints should strictly map to the targeted networks.

---
*PR created automatically by Jules for task [4954465615236698086](https://jules.google.com/task/4954465615236698086) started by @brewmarsh*