### PR TITLE
🎨 Palette: [UX improvement] Add skip links and missing HTML scaffolding

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,7 @@
 ## 2026-07-26 - Accessible Scrollable Regions
 **Learning:** Elements with scrollable overflow (like `<pre class="log-box">`) are not natively focusable by default, meaning keyboard-only users cannot scroll their content using arrow keys.
 **Action:** Always add `tabindex="0"` to visually scrollable regions and include a visible `:focus-visible` outline for sighted keyboard users to ensure they are fully accessible and usable.
+
+## 2024-07-28 - Skip to main content links
+**Learning:** For keyboard and screen reader accessibility, complex pages with heavy navigation require a "Skip to main content" link to bypass repetitive links. Providing this link at the top of the `<body>` element (using `.visually-hidden-focusable`) significantly improves UX.
+**Action:** Always include a skip link immediately after `<body>` and ensure it targets a focusable `<main>` container with `tabindex="-1"` and `outline: none;` to handle keyboard focus correctly. Also ensure standard scaffolding like `lang="en"` and viewport `meta` tags are present in custom templates.

--- a/app/templates/404.html
+++ b/app/templates/404.html
@@ -1,11 +1,14 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Page Not Found</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
 </head>
 <body>
-    <div class="container">
+    <a href="#main-content" class="visually-hidden-focusable p-3">Skip to main content</a>
+    <main id="main-content" class="container" tabindex="-1" style="outline: none;">
         <div class="row">
             <div class="col-md-12 text-center">
                 <h1 class="display-1">404</h1>
@@ -14,6 +17,6 @@
                 <a href="/" class="btn btn-primary">Go to Homepage</a>
             </div>
         </div>
-    </div>
+    </main>
 </body>
 </html>

--- a/app/templates/500.html
+++ b/app/templates/500.html
@@ -1,11 +1,14 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Internal Server Error</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
 </head>
 <body>
-    <div class="container">
+    <a href="#main-content" class="visually-hidden-focusable p-3">Skip to main content</a>
+    <main id="main-content" class="container" tabindex="-1" style="outline: none;">
         <div class="row">
             <div class="col-md-12 text-center">
                 <h1 class="display-1">500</h1>
@@ -14,6 +17,6 @@
                 <a href="/" class="btn btn-primary">Go to Homepage</a>
             </div>
         </div>
-    </div>
+    </main>
 </body>
 </html>

--- a/app/templates/docs.html
+++ b/app/templates/docs.html
@@ -7,11 +7,12 @@
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-    <div class="container">
+    <a href="#main-content" class="visually-hidden-focusable p-3">Skip to main content</a>
+    <main id="main-content" class="container" tabindex="-1" style="outline: none;">
         <a href="/"><h1>Meraki Pi-hole Sync</h1></a>
         <div class="log-container">
             {{ content|safe }}
         </div>
-    </div>
+    </main>
 </body>
 </html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Meraki Pi-hole Sync</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="/static/style.css">
@@ -11,6 +13,7 @@
     </style>
 </head>
 <body>
+    <a href="#main-content" class="visually-hidden-focusable p-3">Skip to main content</a>
     {% if show_welcome_banner %}
     <div id="welcome-screen" role="dialog" aria-modal="true" aria-labelledby="welcome-title">
         <div class="card">
@@ -47,7 +50,7 @@
         </div>
     </nav>
 
-    <div class="container">
+    <main id="main-content" class="container" tabindex="-1" style="outline: none;">
         <div class="row mt-4">
             <div class="col-md-8">
                 <div class="card mt-4" id="charts-card">
@@ -172,7 +175,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    </main>
 
     <div class="toast-container position-fixed bottom-0 end-0 p-3">
       <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">


### PR DESCRIPTION
💡 **What**:
- Added `lang="en"` and `<meta name="viewport" content="width=device-width, initial-scale=1.0">` to all template `<html>` / `<head>` elements (e.g. `index.html`, `404.html`, `500.html`, `docs.html`).
- Inserted a visually hidden but focusable "Skip to main content" link (`<a href="#main-content" class="visually-hidden-focusable p-3">...</a>`) immediately after the `<body>` tag.
- Replaced the primary wrapping `<div class="container">` in all templates with `<main id="main-content" class="container" tabindex="-1" style="outline: none;">`.

🎯 **Why**:
- **A11y (Navigation)**: Screen reader and keyboard-only users need a quick way to bypass repetitive navigation links (like the navbar) and get straight to the primary content of the application.
- **A11y (Structure)**: Modern assistive tools heavily rely on the `lang` attribute and semantic structural tags like `<main>` to infer meaning and pronounce text correctly.
- **Mobile UX**: Viewport tags ensure the pages do not attempt to render as scaled-down desktop pages on mobile devices.

📸 **Before/After**:
- *Before*: Tabbing started at the browser interface and went to the Welcome screen close button or navigation elements without an option to skip. No explicit HTML `lang` was defined.
- *After*: The first tab press immediately focuses on the "Skip to main content" link at the top left of the screen, which, when pressed, correctly shifts document focus directly to the main container.

♿ **Accessibility**: 
- **WCAG 2.4.1 Bypass Blocks**: Fully addresses the requirement by adding a skip link.
- **WCAG 3.1.1 Language of Page**: Handled by adding `lang="en"`.
- Keyboard users now have visual indicators of focus for the skip link and a properly defined anchor target that will not display an ugly blue outline when focused (thanks to `style="outline: none;"`).

---
*PR created automatically by Jules for task [8354994703119162559](https://jules.google.com/task/8354994703119162559) started by @brewmarsh*